### PR TITLE
Give every Docker-building test binary the slow-timeout override

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,7 +2,9 @@
 slow-timeout = { period = "30s", terminate-after = 2 }
 
 # Docker image builds can take minutes on first run (cached afterwards).
-# Gauntlet exec tests also trigger Docker builds via the gauntlet_sandbox fixture.
+# Gauntlet exec tests trigger a build via the gauntlet_sandbox fixture, and
+# every test in the infra binary builds an image directly, so both binaries
+# need the long timeout rather than just the tests whose names say "docker".
 [[profile.default.overrides]]
-filter = "test(~docker) | binary_id(~gauntlet)"
+filter = "test(~docker) | binary_id(~gauntlet) | binary_id(~infra)"
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,6 +8,11 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 # nextest applies timeouts per binary far more legibly than per test name, and
 # because a name-based rule is what issue #9 was: the four image-building tests
 # are named "gauntlet", not "docker".
+# Note that the longer timeout does not currently make these tests pass: the
+# infra tests each build an image in their own process, so they contend for
+# one daemon and the per-test timeout is applied to queued work. They are
+# excluded from every CI job for that reason and so run nowhere — see #37,
+# which proposes serialising them with a nextest test group.
 [[profile.default.overrides]]
 filter = "test(~docker) | binary_id(~gauntlet) | binary_id(~infra)"
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,9 +2,12 @@
 slow-timeout = { period = "30s", terminate-after = 2 }
 
 # Docker image builds can take minutes on first run (cached afterwards).
-# Gauntlet exec tests trigger a build via the gauntlet_sandbox fixture, and
-# every test in the infra binary builds an image directly, so both binaries
-# need the long timeout rather than just the tests whose names say "docker".
+# Gauntlet exec tests trigger a build via the gauntlet_sandbox fixture. Four of
+# the six tests in the infra binary build an image directly; the other two are
+# callgrind benchmarks that build nothing. The override is whole-binary because
+# nextest applies timeouts per binary far more legibly than per test name, and
+# because a name-based rule is what issue #9 was: the four image-building tests
+# are named "gauntlet", not "docker".
 [[profile.default.overrides]]
 filter = "test(~docker) | binary_id(~gauntlet) | binary_id(~infra)"
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,13 +6,13 @@ slow-timeout = { period = "30s", terminate-after = 2 }
 # the six tests in the infra binary build an image directly; the other two are
 # callgrind benchmarks that build nothing. The override is whole-binary because
 # nextest applies timeouts per binary far more legibly than per test name, and
-# because a name-based rule is what issue #9 was: the four image-building tests
-# are named "gauntlet", not "docker".
+# because names are not a reliable proxy: the four image-building tests are named
+# "gauntlet", not "docker".
 # Note that the longer timeout does not currently make these tests pass: the
 # infra tests each build an image in their own process, so they contend for
 # one daemon and the per-test timeout is applied to queued work. They are
 # excluded from every CI job for that reason and so run nowhere — see #37,
 # which proposes serialising them with a nextest test group.
 [[profile.default.overrides]]
-filter = "test(~docker) | binary_id(~gauntlet) | binary_id(~infra)"
+filter = "binary_id(~gauntlet) | binary_id(~infra) | binary_id(~harness)"
 slow-timeout = { period = "120s", terminate-after = 2 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --features cli -E 'not binary(gauntlet)'
+      - run: cargo nextest run --features cli -E 'not (binary(gauntlet) | binary(infra))'
+
+  test-docker:
+    name: Docker infrastructure tests
+    runs-on: ubuntu-latest
+    # Not required: image builds depend on the Docker build cache, which is a
+    # slow and flaky thing to gate merges on. Same convention as test-gauntlet.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
+      - run: cargo nextest run --features cli -E 'binary(infra)'
 
   test-gauntlet:
     name: Gauntlet tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --features cli -E 'not (binary(gauntlet) | binary(infra))'
+      # --no-fail-fast is required by the interim merge rule while main is red
+      # (#22): that rule compares complete failing sets against the merge base,
+      # and fail-fast truncates them at an arbitrary point. Reconsider once #22
+      # makes main green.
+      - run: cargo nextest run --features cli --no-fail-fast -E 'not (binary(gauntlet) | binary(infra))'
 
   test-gauntlet:
     name: Gauntlet tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
-      # --no-fail-fast is required by the interim merge rule while main is red
-      # (#22): that rule compares complete failing sets against the merge base,
-      # and fail-fast truncates them at an arbitrary point. Reconsider once #22
-      # makes main green.
+      # Required while main is red (#22): the interim merge rule compares complete
+      # failing sets against the merge base, and fail-fast truncates them. #22
+      # closing is the condition for dropping this.
       - run: cargo nextest run --features cli --no-fail-fast -E 'not (binary(gauntlet) | binary(infra))'
 
   test-gauntlet:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,19 +30,6 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --features cli -E 'not (binary(gauntlet) | binary(infra))'
 
-  test-docker:
-    name: Docker infrastructure tests
-    runs-on: ubuntu-latest
-    # Not required: image builds depend on the Docker build cache, which is a
-    # slow and flaky thing to gate merges on. Same convention as test-gauntlet.
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --features cli -E 'binary(infra)'
-
   test-gauntlet:
     name: Gauntlet tests
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,10 @@
 
 ```sh
 pip install pre-commit && pre-commit install   # one-time setup (installs pre-commit + commit-msg hooks)
-cargo nextest run --features cli               # all tests (excludes conformance)
-cargo nextest run -P conformance --features cli # conformance tests (requires Docker image)
+cargo nextest run --features cli               # everything, including Docker image builds
+cargo nextest run --features cli -E 'not (binary(gauntlet) | binary(infra))'  # skip Docker work
+THAUM_GAUNTLET_NO_SANDBOX=1 \
+  cargo nextest run --features cli -E 'binary(gauntlet)'                      # gauntlet on the host
 cargo test --features cli                      # also works (same harness)
 pre-commit run --all-files                     # lint + format + #[test] guard
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,10 @@ harness = false
 name = "infra"
 harness = false
 
+[[test]]
+name = "harness"
+harness = false
+
 [[bench]]
 name = "bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 pretty_assertions = "1"
+serde_json = "1"
 yaml-rust2 = "0.8"
 libtest-mimic = "0.8"
 skuld = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ windows = { version = "0.62", features = [
 
 [dev-dependencies]
 pretty_assertions = "1"
-serde_json = "1"
 yaml-rust2 = "0.8"
 libtest-mimic = "0.8"
 skuld = "0.1"

--- a/tests/common/docker.rs
+++ b/tests/common/docker.rs
@@ -12,6 +12,12 @@
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+/// Substring emitted when the gauntlet image is about to be built.
+///
+/// Shared so that a guard asserting a build did *not* happen cannot be silently
+/// defeated by rewording the message here.
+pub const IMAGE_BUILD_MARKER: &str = "building Docker image";
+
 // Precondition ========================================================================================================
 
 fn docker_available() -> Result<(), String> {
@@ -41,7 +47,7 @@ impl Drop for GauntletImage {
 fn gauntlet_image() -> Result<GauntletImage, String> {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let dockerfile = manifest_dir.join("tests/docker/Dockerfile");
-    eprintln!("gauntlet: building Docker image...");
+    eprintln!("gauntlet: {IMAGE_BUILD_MARKER}...");
     let id = thaum_testkit::docker::build_image(&dockerfile, manifest_dir, None)?;
     eprintln!("gauntlet: built Docker image {}", &id[..12.min(id.len())]);
     Ok(GauntletImage { id })

--- a/tests/gauntlet.rs
+++ b/tests/gauntlet.rs
@@ -443,9 +443,14 @@ fn main() {
             .iter()
             .all(|req| req.eval().is_ok());
 
+    // Enumerating tests must have no side effects: `cargo nextest list` runs
+    // every test binary with `--list`, so warming up here would make listing
+    // build a Docker image (issue #20).
+    let listing = std::env::args().any(|a| a == "--list");
+
     // Eagerly build the Docker image and start the container before tests run.
     // This avoids per-test timeout issues (Docker build can take minutes).
-    if exec_available && !no_sandbox {
+    if exec_available && !no_sandbox && !listing {
         skuld::warm_up("gauntlet_sandbox");
     }
 

--- a/tests/gauntlet.rs
+++ b/tests/gauntlet.rs
@@ -445,8 +445,10 @@ fn main() {
 
     // Enumerating tests must have no side effects: `cargo nextest list` runs
     // every test binary with `--list`, so warming up here would make listing
-    // build a Docker image (issue #20).
-    let listing = std::env::args().any(|a| a == "--list");
+    // build a Docker image (issue #20). Parse with libtest-mimic rather than
+    // scanning argv, which also covers `--help`: `from_args` prints help and
+    // exits before returning, so the warm-up below is never reached.
+    let listing = libtest_mimic::Arguments::from_args().list;
 
     // Eagerly build the Docker image and start the container before tests run.
     // This avoids per-test timeout issues (Docker build can take minutes).

--- a/tests/gauntlet.rs
+++ b/tests/gauntlet.rs
@@ -436,19 +436,22 @@ fn main() {
     let no_sandbox = std::env::var("THAUM_GAUNTLET_NO_SANDBOX").is_ok_and(|v| v == "1");
     NO_SANDBOX.store(no_sandbox, std::sync::atomic::Ordering::Relaxed);
 
-    // Check if gauntlet execution is available. For Docker mode, this only runs
-    // `docker info` (fast, idempotent).
+    // Enumerating tests must have no side effects, so nothing below this point
+    // may touch the Docker daemon while listing. Parse with libtest-mimic rather
+    // than scanning argv, which also covers `--help`: `from_args` prints help
+    // and exits before returning.
+    let listing = libtest_mimic::Arguments::from_args().list;
+
+    // Whether exec tests can run. The probe shells out to `docker info`, which
+    // has no timeout and blocks indefinitely against an unresponsive DOCKER_HOST
+    // — so it is skipped while listing, and every test is listed instead. A test
+    // listed here but unavailable at run time is reported as such by skuld; a
+    // listing that hangs is not recoverable.
     let exec_available = no_sandbox
+        || listing
         || skuld::collect_fixture_requires(&["gauntlet_sandbox"])
             .iter()
             .all(|req| req.eval().is_ok());
-
-    // Enumerating tests must have no side effects: `cargo nextest list` runs
-    // every test binary with `--list`, so warming up here would make listing
-    // build a Docker image (issue #20). Parse with libtest-mimic rather than
-    // scanning argv, which also covers `--help`: `from_args` prints help and
-    // exits before returning, so the warm-up below is never reached.
-    let listing = libtest_mimic::Arguments::from_args().list;
 
     // Eagerly build the Docker image and start the container before tests run.
     // This avoids per-test timeout issues (Docker build can take minutes).

--- a/tests/harness.rs
+++ b/tests/harness.rs
@@ -1,0 +1,15 @@
+//! Harness tests — guard the test configuration that CI depends on.
+//!
+//! Separate from `infra` because nothing here builds a Docker image. `infra`
+//! is excluded from the gating CI job precisely because it does; these tests
+//! must run there, so they need a binary that is not excluded.
+
+#[path = "common/mod.rs"]
+mod common;
+
+#[path = "harness/nextest_config.rs"]
+mod nextest_config;
+
+fn main() {
+    skuld::run_all();
+}

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -1,0 +1,190 @@
+//! Guards for the nextest filter expressions that CI and the timeout policy
+//! depend on.
+//!
+//! Both tests read their filter expression out of the file that actually
+//! governs it — `.config/nextest.toml` or the workflow — and ask nextest to
+//! evaluate it. Hardcoding the expressions here would let the guard drift away
+//! from what CI runs, which is the failure these tests exist to catch.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::common::labels::INFRA;
+
+skuld::default_labels!(INFRA);
+
+/// Binaries whose tests may build a Docker image.
+///
+/// `infra` builds both the gauntlet and bench images; `gauntlet` triggers a
+/// build through the `gauntlet_sandbox` fixture. Both therefore need the long
+/// slow-timeout, and neither belongs in a required CI job.
+const DOCKER_BUILDING_BINARIES: &[&str] = &["thaum::infra", "thaum::gauntlet"];
+
+fn nextest_available() -> Result<(), String> {
+    Command::new("cargo")
+        .args(["nextest", "--version"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+        .then_some(())
+        .ok_or_else(|| "cargo-nextest not installed".into())
+}
+
+fn project_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(rel: &str) -> String {
+    let path: PathBuf = project_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Extract the value of a `key = "value"` line, given the key.
+fn quoted_value_after(line: &str, key: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix(key)?.trim_start().strip_prefix('=')?;
+    let rest = rest.trim_start().strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// The `filter` of the `[[profile.default.overrides]]` block that grants the
+/// long slow-timeout.
+fn slow_timeout_override_filter() -> String {
+    let toml = read(".config/nextest.toml");
+    let mut in_override = false;
+    for line in toml.lines() {
+        if line.trim() == "[[profile.default.overrides]]" {
+            in_override = true;
+            continue;
+        }
+        if in_override {
+            if let Some(v) = quoted_value_after(line, "filter") {
+                return v;
+            }
+            if line.trim_start().starts_with('[') {
+                in_override = false;
+            }
+        }
+    }
+    panic!("no `filter = \"...\"` found in a [[profile.default.overrides]] block of .config/nextest.toml");
+}
+
+/// The `-E '<expr>'` of the `cargo nextest run` step in the given workflow job.
+fn workflow_filter(job: &str) -> String {
+    let yaml = read(".github/workflows/ci.yml");
+    let mut in_job = false;
+    for line in yaml.lines() {
+        // Job headers sit at exactly two spaces of indent under `jobs:`.
+        if let Some(name) = line.strip_prefix("  ").and_then(|l| l.strip_suffix(':')) {
+            if !name.starts_with(' ') && !name.starts_with('-') {
+                in_job = name == job;
+                continue;
+            }
+        }
+        if in_job && line.contains("cargo nextest run") {
+            let after = line
+                .split("-E ")
+                .nth(1)
+                .unwrap_or_else(|| panic!("job `{job}` runs nextest without an -E filter: {line}"));
+            let after = after
+                .trim_start()
+                .strip_prefix('\'')
+                .unwrap_or_else(|| panic!("job `{job}`: expected the -E expression in single quotes: {line}"));
+            let end = after
+                .find('\'')
+                .unwrap_or_else(|| panic!("job `{job}`: unterminated -E expression: {line}"));
+            return after[..end].to_string();
+        }
+    }
+    panic!("no `cargo nextest run` step found in workflow job `{job}`");
+}
+
+/// Run `cargo nextest list -E expr`, returning (stdout, stderr).
+fn nextest_list(expr: &str) -> (String, String) {
+    let output = Command::new("cargo")
+        .args(["nextest", "list", "--features", "cli", "--cargo-quiet", "-E", expr])
+        .current_dir(project_root())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap_or_else(|e| panic!("cargo nextest list failed to start: {e}"));
+    assert!(
+        output.status.success(),
+        "cargo nextest list -E {expr:?} failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Binary ids of every test nextest selects under `expr`.
+fn binaries_selected_by(expr: &str) -> BTreeSet<String> {
+    let (stdout, _) = nextest_list(expr);
+    // Non-interactive listing prints one line per test: "<binary-id> <test name>".
+    // Test names contain spaces, binary ids do not, so the id is the first field.
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Listing tests must not build anything.
+///
+/// `cargo nextest list` runs every selected binary with `--list`, and the
+/// gauntlet binary used to warm up its Docker fixture from `main()` — so
+/// enumerating tests built an image (issue #20). The guards above evaluate a
+/// filter that selects the gauntlet binary, so a regression here would make
+/// them slow and Docker-dependent rather than cheap.
+#[skuld::test(requires = [nextest_available])]
+fn listing_tests_does_not_build_docker_images() {
+    let filter = slow_timeout_override_filter();
+    let (_, stderr) = nextest_list(&filter);
+    assert!(
+        !stderr.contains("building Docker image"),
+        "listing tests under `{filter}` built a Docker image — enumeration must have no side \
+         effects (issue #20).\nstderr:\n{stderr}"
+    );
+}
+
+#[skuld::test(requires = [nextest_available])]
+fn slow_timeout_override_covers_every_docker_building_binary() {
+    let filter = slow_timeout_override_filter();
+    let selected = binaries_selected_by(&filter);
+    for binary in DOCKER_BUILDING_BINARIES {
+        assert!(
+            selected.contains(*binary),
+            "`{binary}` can build a Docker image but is not covered by the slow-timeout override \
+             `{filter}`, so it gets the 30s default and is killed mid-build.\nSelected: {selected:?}"
+        );
+    }
+}
+
+#[skuld::test(requires = [nextest_available])]
+fn gating_job_selects_no_docker_building_binary() {
+    let filter = workflow_filter("test");
+    let selected = binaries_selected_by(&filter);
+    for binary in DOCKER_BUILDING_BINARIES {
+        assert!(
+            !selected.contains(*binary),
+            "the gating CI job's filter `{filter}` selects `{binary}`, which builds Docker images \
+             — a required check must not depend on the Docker build cache"
+        );
+    }
+}
+
+#[skuld::test(requires = [nextest_available])]
+fn gating_job_runs_these_guards() {
+    let filter = workflow_filter("test");
+    let selected = binaries_selected_by(&filter);
+    assert!(
+        selected.contains("thaum::harness"),
+        "the gating CI job's filter `{filter}` does not select `thaum::harness`, so these guards \
+         would never run in CI.\nSelected: {selected:?}"
+    );
+}

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -181,50 +181,66 @@ fn test_binary_path(binary_id: &str) -> PathBuf {
 
 // Filter guards -------------------------------------------------------------------------------------------------------
 
-/// Every Docker-building binary that has listable tests is covered by the override.
+/// The Docker-building binaries, confirmed enumerable before anything is
+/// asserted about them.
 ///
-/// Compared against the *unfiltered* listing rather than a fixed expectation:
-/// skuld omits tests whose `requires` preconditions fail, so on a machine
-/// without Docker every test in `thaum::infra` is unavailable and the binary
-/// does not appear at all. Asserting it is present would then fail for a reason
-/// that has nothing to do with the timeout policy — which is what happened on
-/// the macOS CI runner.
-#[skuld::test(requires = [nextest_available])]
+/// Every guard below asserts something *about* these binaries, and an assertion
+/// over an absent binary passes having checked nothing: a loop that runs zero
+/// times reports PASS. That is how two earlier versions of these guards
+/// reported green while broken.
+///
+/// The absence is real, not hypothetical — skuld omits tests whose `requires`
+/// preconditions fail, so where Docker is missing every test in `thaum::infra`
+/// is unavailable and the binary does not appear in the listing at all. On the
+/// CI legs that is macOS only; Linux and Windows both have a daemon.
+///
+/// The fix for that is a `requires` precondition, where an unmet condition is
+/// reported as unavailable and stays visible — never a silent skip inside the
+/// test body.
+fn listable_docker_binaries() -> Vec<&'static str> {
+    let present = binaries_selected_by("all()");
+    let listable: Vec<&'static str> = DOCKER_BUILDING_BINARIES
+        .iter()
+        .copied()
+        .filter(|b| present.contains(*b))
+        .collect();
+    assert_eq!(
+        listable.len(),
+        DOCKER_BUILDING_BINARIES.len(),
+        "expected every Docker-building binary to be enumerable, but only {listable:?} are. \
+         Any assertion about the missing ones would pass having checked nothing.\nPresent: {present:?}"
+    );
+    listable
+}
+
+/// Every Docker-building binary is covered by the slow-timeout override.
+#[skuld::test(requires = [nextest_available, docker_available])]
 fn slow_timeout_override_covers_every_docker_building_binary() {
     let filter = slow_timeout_override_filter();
     let selected = binaries_selected_by(&filter);
-    let present = binaries_selected_by("all()");
-    assert!(
-        present.contains("thaum::gauntlet"),
-        "no Docker-building binary has listable tests here, so this guard checked nothing.\n\
-         Present: {present:?}"
-    );
-    for binary in DOCKER_BUILDING_BINARIES {
-        if !present.contains(*binary) {
-            continue;
-        }
+    for binary in listable_docker_binaries() {
         assert!(
-            selected.contains(*binary),
+            selected.contains(binary),
             "`{binary}` can build a Docker image but is not covered by the slow-timeout override \
              `{filter}`, so it gets the 30s default and is killed mid-build.\nSelected: {selected:?}"
         );
     }
 }
 
-#[skuld::test(requires = [nextest_available])]
+#[skuld::test(requires = [nextest_available, docker_available])]
 fn gating_job_selects_no_docker_building_binary() {
     let filter = workflow_filter("test");
     let selected = binaries_selected_by(&filter);
-    // Positive control: an assertion of absence passes trivially against an
-    // empty set, so confirm the filter selected something first.
+    // An assertion of absence is vacuous twice over: against an empty selection,
+    // and against a binary that cannot be enumerated here at all.
     assert!(
         !selected.is_empty(),
         "the gating CI job's filter `{filter}` selected no tests at all, so asserting what it \
          does not select proves nothing"
     );
-    for binary in DOCKER_BUILDING_BINARIES {
+    for binary in listable_docker_binaries() {
         assert!(
-            !selected.contains(*binary),
+            !selected.contains(binary),
             "the gating CI job's filter `{filter}` selects `{binary}`, which builds Docker images \
              — a required check must not depend on the Docker build cache"
         );

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -22,6 +22,15 @@ skuld::default_labels!(INFRA);
 /// CI exclusion are both whole-binary, so this list is of binaries, not tests.
 const DOCKER_BUILDING_BINARIES: &[&str] = &["thaum::infra", "thaum::gauntlet"];
 
+/// Binaries needing the long slow-timeout.
+///
+/// A superset of the above: `harness` builds no image in normal operation, but
+/// `listing_tests_builds_no_image` triggers one precisely when the regression it
+/// guards is present. Under the 30s default that surfaces as "test timed out"
+/// instead of the guard's diagnostic, and leaves a `docker build` running
+/// daemon-side.
+const SLOW_TIMEOUT_BINARIES: &[&str] = &["thaum::infra", "thaum::gauntlet", "thaum::harness"];
+
 fn nextest_available() -> Result<(), String> {
     Command::new("cargo")
         .args(["nextest", "--version"])
@@ -52,10 +61,9 @@ fn read(rel: &str) -> String {
 
 /// Strip ANSI SGR sequences.
 ///
-/// Belt and braces: the cargo invocations below force colour off, but `ci.yml`
-/// sets `CARGO_TERM_COLOR: always` workflow-wide, and a guard that parses
-/// coloured output as if it were plain is exactly the failure mode that hid
-/// itself once already.
+/// `ci.yml` sets `CARGO_TERM_COLOR: always` workflow-wide, so colour is forced
+/// off on both the outer and inner invocations; this is the remaining defence if
+/// either is missed.
 fn strip_ansi(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars();
@@ -81,26 +89,37 @@ fn quoted_value_after(line: &str, key: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-/// The `filter` of the `[[profile.default.overrides]]` block granting the long
-/// slow-timeout.
+/// The `filter` of the override block that sets `slow-timeout`.
+///
+/// nextest allows arbitrarily many `[[profile.default.overrides]]` blocks, so
+/// taking the first one silently reads whichever override happens to come first
+/// — a later `retries` or `test-group` block would redirect this guard onto an
+/// unrelated filter. Selects by the key that matters and fails if the answer is
+/// not unique.
 fn slow_timeout_override_filter() -> String {
     let toml = read(".config/nextest.toml");
-    let mut in_override = false;
-    for line in toml.lines() {
-        if line.trim() == "[[profile.default.overrides]]" {
-            in_override = true;
-            continue;
-        }
-        if in_override {
-            if let Some(v) = quoted_value_after(line, "filter") {
-                return v;
-            }
-            if line.trim_start().starts_with('[') {
-                in_override = false;
-            }
+    let mut matching: Vec<String> = Vec::new();
+    for block in toml.split("[[profile.default.overrides]]").skip(1) {
+        // A block ends at the next section header.
+        let block: String = block
+            .lines()
+            .take_while(|l| !l.trim_start().starts_with('['))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let filter = block.lines().find_map(|l| quoted_value_after(l, "filter"));
+        let sets_timeout = block.lines().any(|l| l.trim_start().starts_with("slow-timeout"));
+        if let (Some(f), true) = (filter, sets_timeout) {
+            matching.push(f);
         }
     }
-    panic!("no `filter = \"...\"` found in a [[profile.default.overrides]] block of .config/nextest.toml");
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one [[profile.default.overrides]] block setting slow-timeout in \
+         .config/nextest.toml, found {}: {matching:?}",
+        matching.len()
+    );
+    matching.remove(0)
 }
 
 /// The `-E '<expr>'` of the `cargo nextest run` step in the given workflow job.
@@ -189,24 +208,16 @@ fn test_binary_path(binary_id: &str) -> PathBuf {
 /// times reports PASS. That is how two earlier versions of these guards
 /// reported green while broken.
 ///
-/// The absence is real, not hypothetical — skuld omits tests whose `requires`
-/// preconditions fail, so where Docker is missing every test in `thaum::infra`
-/// is unavailable and the binary does not appear in the listing at all. On the
-/// CI legs that is macOS only; Linux and Windows both have a daemon.
-///
-/// The fix for that is a `requires` precondition, where an unmet condition is
-/// reported as unavailable and stays visible — never a silent skip inside the
-/// test body.
-fn listable_docker_binaries() -> Vec<&'static str> {
+/// skuld omits tests whose `requires` preconditions fail, so where Docker is
+/// missing every test in `thaum::infra` is unavailable and the binary does not
+/// appear at all. Preconditions therefore belong in `requires`, where an unmet
+/// one is reported as unavailable, never as a silent skip inside a test body.
+fn listable(binaries: &[&'static str]) -> Vec<&'static str> {
     let present = binaries_selected_by("all()");
-    let listable: Vec<&'static str> = DOCKER_BUILDING_BINARIES
-        .iter()
-        .copied()
-        .filter(|b| present.contains(*b))
-        .collect();
+    let listable: Vec<&'static str> = binaries.iter().copied().filter(|b| present.contains(*b)).collect();
     assert_eq!(
         listable.len(),
-        DOCKER_BUILDING_BINARIES.len(),
+        binaries.len(),
         "expected every Docker-building binary to be enumerable, but only {listable:?} are. \
          Any assertion about the missing ones would pass having checked nothing.\nPresent: {present:?}"
     );
@@ -218,7 +229,7 @@ fn listable_docker_binaries() -> Vec<&'static str> {
 fn slow_timeout_override_covers_every_docker_building_binary() {
     let filter = slow_timeout_override_filter();
     let selected = binaries_selected_by(&filter);
-    for binary in listable_docker_binaries() {
+    for binary in listable(SLOW_TIMEOUT_BINARIES) {
         assert!(
             selected.contains(binary),
             "`{binary}` can build a Docker image but is not covered by the slow-timeout override \
@@ -238,7 +249,7 @@ fn gating_job_selects_no_docker_building_binary() {
         "the gating CI job's filter `{filter}` selected no tests at all, so asserting what it \
          does not select proves nothing"
     );
-    for binary in listable_docker_binaries() {
+    for binary in listable(DOCKER_BUILDING_BINARIES) {
         assert!(
             !selected.contains(binary),
             "the gating CI job's filter `{filter}` selects `{binary}`, which builds Docker images \
@@ -258,13 +269,12 @@ fn gating_job_runs_these_guards() {
     );
 }
 
-/// The guards must survive the environment CI actually runs them in.
+/// Binary ids parse out of coloured output.
 ///
-/// `ci.yml` sets `CARGO_TERM_COLOR: always` workflow-wide. An earlier version
-/// of this file passed `--color never` to the outer command only, so the inner
-/// `cargo nextest list` inherited the variable and emitted ANSI codes into the
-/// output the assertions parse — and the guards failed in the one job they were
-/// written to protect.
+/// `ci.yml` sets `CARGO_TERM_COLOR: always` workflow-wide, and it is inherited by
+/// the inner `cargo nextest list` unless cleared — `--color never` on the outer
+/// command alone does not reach it. This guard forces colour off on both and
+/// checks parsing under a forced-colour environment.
 #[skuld::test(requires = [nextest_available])]
 fn filter_parsing_survives_forced_colour() {
     let filter = workflow_filter("test");
@@ -289,57 +299,48 @@ fn filter_parsing_survives_forced_colour() {
 
 // Side-effect guard ---------------------------------------------------------------------------------------------------
 
-/// Enumerating tests must build nothing (issue #20).
+/// Enumerating tests must build nothing.
 ///
-/// Asserts against the gauntlet binary's **own stderr**, not against
-/// `cargo nextest list`'s output: nextest discards a test binary's stderr when
-/// listing succeeds, so a guard phrased against the outer command's output can
-/// never fail and reports success forever.
+/// Asserts against the gauntlet binary's **own stderr**: nextest discards a test
+/// binary's stderr when listing succeeds, so a guard phrased against the outer
+/// command's output can never fail.
 ///
-/// Three things this guard needs to avoid passing vacuously:
+/// The child's environment is scrubbed of the two variables that would make this
+/// pass without checking anything. `THAUM_GAUNTLET_NO_SANDBOX` short-circuits the
+/// code path under test; `SKULD_LABELS` filters the child's listing, so an
+/// inherited value can empty it. Both are documented developer knobs, so both are
+/// plausible in the environment a developer runs this from.
 ///
-/// - `THAUM_GAUNTLET_NO_SANDBOX` is removed from the child's environment.
-///   With it set the child short-circuits before the warm-up and emits no
-///   marker, so an inherited value would make the guard pass against unfixed
-///   code — and `CONTRIBUTING.md` teaches that variable two lines above the
-///   command a developer would run.
-/// - The child's exit status is checked. A child dying before it reaches the
-///   fixture also produces stderr without the marker.
-/// - A positive control confirms the child got far enough to list tests, so
-///   "no marker" means "did not warm up" rather than "did not run".
-///
-/// Note it is skipped where Docker is absent, which is correct — without a
-/// daemon the fixture's precondition fails and no warm-up is attempted — but it
-/// does mean issue #20 has no regression cover on the macOS CI runner.
+/// Skipped where Docker is absent, which is correct — without a daemon no warm-up
+/// is attempted — but it does mean this guard does not run on macOS CI.
 #[skuld::test(requires = [nextest_available, docker_available], labels = [DOCKER])]
 fn listing_tests_builds_no_image() {
     let binary = test_binary_path("thaum::gauntlet");
     let output = Command::new(&binary)
         .arg("--list")
         .env_remove("THAUM_GAUNTLET_NO_SANDBOX")
+        .env_remove("SKULD_LABELS")
         .current_dir(project_root())
         .output()
         .unwrap_or_else(|e| panic!("running {} --list: {e}", binary.display()));
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let listed = String::from_utf8_lossy(&output.stdout);
 
     assert!(
         output.status.success(),
-        "`{} --list` exited {:?} — a child that dies early produces no marker and would make \
-         this guard pass for the wrong reason.\nstderr:\n{stderr}",
+        "`{} --list` exited {:?}; a child that dies early emits no marker either.\nstderr:\n{stderr}",
         binary.display(),
         output.status.code()
     );
     assert!(
-        stdout.lines().filter(|l| !l.trim().is_empty()).count() > 100,
-        "`{} --list` listed almost nothing, so the absence of a build marker proves nothing.\n\
-         stdout:\n{stdout}",
+        listed.lines().any(|l| !l.trim().is_empty()),
+        "`{} --list` listed nothing, so the absence of a build marker proves nothing",
         binary.display()
     );
     assert!(
-        !stderr.contains("building Docker image"),
-        "`{} --list` warmed up the Docker fixture — enumerating tests must have no side effects \
-         (issue #20).\nstderr:\n{stderr}",
+        !stderr.contains(crate::common::docker::IMAGE_BUILD_MARKER),
+        "`{} --list` warmed up the Docker fixture; enumerating tests must have no side \
+         effects.\nstderr:\n{stderr}",
         binary.display()
     );
 }

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -180,11 +180,28 @@ fn test_binary_path(binary_id: &str) -> PathBuf {
 
 // Filter guards -------------------------------------------------------------------------------------------------------
 
+/// Every Docker-building binary that has listable tests is covered by the override.
+///
+/// Compared against the *unfiltered* listing rather than a fixed expectation:
+/// skuld omits tests whose `requires` preconditions fail, so on a machine
+/// without Docker every test in `thaum::infra` is unavailable and the binary
+/// does not appear at all. Asserting it is present would then fail for a reason
+/// that has nothing to do with the timeout policy — which is what happened on
+/// the macOS CI runner.
 #[skuld::test(requires = [nextest_available])]
 fn slow_timeout_override_covers_every_docker_building_binary() {
     let filter = slow_timeout_override_filter();
     let selected = binaries_selected_by(&filter);
+    let present = binaries_selected_by("all()");
+    assert!(
+        present.contains("thaum::gauntlet"),
+        "no Docker-building binary has listable tests here, so this guard checked nothing.\n\
+         Present: {present:?}"
+    );
     for binary in DOCKER_BUILDING_BINARIES {
+        if !present.contains(*binary) {
+            continue;
+        }
         assert!(
             selected.contains(*binary),
             "`{binary}` can build a Docker image but is not covered by the slow-timeout override \

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -14,11 +14,12 @@ use crate::common::labels::{DOCKER, INFRA};
 
 skuld::default_labels!(INFRA);
 
-/// Binaries whose tests may build a Docker image.
+/// Binaries containing tests that may build a Docker image.
 ///
-/// `infra` builds both the gauntlet and bench images; `gauntlet` triggers a
-/// build through the `gauntlet_sandbox` fixture. Both therefore need the long
-/// slow-timeout, and neither belongs in a required CI job.
+/// Four of `infra`'s six tests build the gauntlet or bench image directly; the
+/// other two are callgrind benchmarks that build nothing. `gauntlet` triggers a
+/// build through the `gauntlet_sandbox` fixture. The timeout override and the
+/// CI exclusion are both whole-binary, so this list is of binaries, not tests.
 const DOCKER_BUILDING_BINARIES: &[&str] = &["thaum::infra", "thaum::gauntlet"];
 
 fn nextest_available() -> Result<(), String> {
@@ -214,6 +215,13 @@ fn slow_timeout_override_covers_every_docker_building_binary() {
 fn gating_job_selects_no_docker_building_binary() {
     let filter = workflow_filter("test");
     let selected = binaries_selected_by(&filter);
+    // Positive control: an assertion of absence passes trivially against an
+    // empty set, so confirm the filter selected something first.
+    assert!(
+        !selected.is_empty(),
+        "the gating CI job's filter `{filter}` selected no tests at all, so asserting what it \
+         does not select proves nothing"
+    );
     for binary in DOCKER_BUILDING_BINARIES {
         assert!(
             !selected.contains(*binary),
@@ -271,19 +279,67 @@ fn filter_parsing_survives_forced_colour() {
 /// `cargo nextest list`'s output: nextest discards a test binary's stderr when
 /// listing succeeds, so a guard phrased against the outer command's output can
 /// never fail and reports success forever.
+///
+/// Three things this guard needs to avoid passing vacuously:
+///
+/// - `THAUM_GAUNTLET_NO_SANDBOX` is removed from the child's environment.
+///   With it set the child short-circuits before the warm-up and emits no
+///   marker, so an inherited value would make the guard pass against unfixed
+///   code — and `CONTRIBUTING.md` teaches that variable two lines above the
+///   command a developer would run.
+/// - The child's exit status is checked. A child dying before it reaches the
+///   fixture also produces stderr without the marker.
+/// - A positive control confirms the child got far enough to list tests, so
+///   "no marker" means "did not warm up" rather than "did not run".
+///
+/// Note it is skipped where Docker is absent, which is correct — without a
+/// daemon the fixture's precondition fails and no warm-up is attempted — but it
+/// does mean issue #20 has no regression cover on the macOS CI runner.
 #[skuld::test(requires = [nextest_available, docker_available], labels = [DOCKER])]
-fn listing_does_not_warm_up_the_docker_fixture() {
+fn listing_tests_builds_no_image() {
     let binary = test_binary_path("thaum::gauntlet");
     let output = Command::new(&binary)
         .arg("--list")
+        .env_remove("THAUM_GAUNTLET_NO_SANDBOX")
         .current_dir(project_root())
         .output()
         .unwrap_or_else(|e| panic!("running {} --list: {e}", binary.display()));
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "`{} --list` exited {:?} — a child that dies early produces no marker and would make \
+         this guard pass for the wrong reason.\nstderr:\n{stderr}",
+        binary.display(),
+        output.status.code()
+    );
+    assert!(
+        stdout.lines().filter(|l| !l.trim().is_empty()).count() > 100,
+        "`{} --list` listed almost nothing, so the absence of a build marker proves nothing.\n\
+         stdout:\n{stdout}",
+        binary.display()
+    );
     assert!(
         !stderr.contains("building Docker image"),
         "`{} --list` warmed up the Docker fixture — enumerating tests must have no side effects \
          (issue #20).\nstderr:\n{stderr}",
         binary.display()
+    );
+}
+
+/// `CONTRIBUTING.md` documents the Docker-free filter by copying it.
+///
+/// Nothing otherwise keeps that copy in step with `ci.yml`, and a developer
+/// following stale instructions gets Docker builds they were told they had
+/// opted out of.
+#[skuld::test]
+fn contributing_documents_the_gating_filter_verbatim() {
+    let filter = workflow_filter("test");
+    let doc = read("CONTRIBUTING.md");
+    assert!(
+        doc.contains(&filter),
+        "CONTRIBUTING.md does not contain the gating job's filter `{filter}` verbatim, so the \
+         documented way to skip Docker work has drifted from what CI runs"
     );
 }

--- a/tests/harness/nextest_config.rs
+++ b/tests/harness/nextest_config.rs
@@ -1,8 +1,8 @@
 //! Guards for the nextest filter expressions that CI and the timeout policy
-//! depend on.
+//! depend on, and for the rule that enumerating tests has no side effects.
 //!
-//! Both tests read their filter expression out of the file that actually
-//! governs it — `.config/nextest.toml` or the workflow — and ask nextest to
+//! Each guard reads its filter expression out of the file that actually
+//! governs it — `.config/nextest.toml` or the workflow — and asks nextest to
 //! evaluate it. Hardcoding the expressions here would let the guard drift away
 //! from what CI runs, which is the failure these tests exist to catch.
 
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::common::labels::INFRA;
+use crate::common::labels::{DOCKER, INFRA};
 
 skuld::default_labels!(INFRA);
 
@@ -32,6 +32,14 @@ fn nextest_available() -> Result<(), String> {
         .ok_or_else(|| "cargo-nextest not installed".into())
 }
 
+fn docker_available() -> Result<(), String> {
+    if thaum_testkit::docker::available() {
+        Ok(())
+    } else {
+        Err("Docker not available".into())
+    }
+}
+
 fn project_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
 }
@@ -39,6 +47,29 @@ fn project_root() -> &'static Path {
 fn read(rel: &str) -> String {
     let path: PathBuf = project_root().join(rel);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// Strip ANSI SGR sequences.
+///
+/// Belt and braces: the cargo invocations below force colour off, but `ci.yml`
+/// sets `CARGO_TERM_COLOR: always` workflow-wide, and a guard that parses
+/// coloured output as if it were plain is exactly the failure mode that hid
+/// itself once already.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            for e in chars.by_ref() {
+                if e.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// Extract the value of a `key = "value"` line, given the key.
@@ -49,8 +80,8 @@ fn quoted_value_after(line: &str, key: &str) -> Option<String> {
     Some(rest[..end].to_string())
 }
 
-/// The `filter` of the `[[profile.default.overrides]]` block that grants the
-/// long slow-timeout.
+/// The `filter` of the `[[profile.default.overrides]]` block granting the long
+/// slow-timeout.
 fn slow_timeout_override_filter() -> String {
     let toml = read(".config/nextest.toml");
     let mut in_override = false;
@@ -101,32 +132,35 @@ fn workflow_filter(job: &str) -> String {
     panic!("no `cargo nextest run` step found in workflow job `{job}`");
 }
 
-/// Run `cargo nextest list -E expr`, returning (stdout, stderr).
-fn nextest_list(expr: &str) -> (String, String) {
+/// Run a `cargo nextest` subcommand with colour forced off, returning stdout.
+///
+/// `CARGO_TERM_COLOR` is cleared explicitly: `--color never` governs only the
+/// invocation it is passed to, while the environment variable is inherited by
+/// everything underneath.
+fn nextest_stdout(args: &[&str]) -> String {
     let output = Command::new("cargo")
-        .args(["nextest", "list", "--features", "cli", "--cargo-quiet", "-E", expr])
+        .arg("nextest")
+        .args(args)
+        .args(["--features", "cli", "--color", "never", "--cargo-quiet"])
+        .env("CARGO_TERM_COLOR", "never")
         .current_dir(project_root())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .unwrap_or_else(|e| panic!("cargo nextest list failed to start: {e}"));
+        .unwrap_or_else(|e| panic!("cargo nextest failed to start: {e}"));
     assert!(
         output.status.success(),
-        "cargo nextest list -E {expr:?} failed:\n{}",
+        "cargo nextest {args:?} failed:\n{}",
         String::from_utf8_lossy(&output.stderr)
     );
-    (
-        String::from_utf8_lossy(&output.stdout).into_owned(),
-        String::from_utf8_lossy(&output.stderr).into_owned(),
-    )
+    strip_ansi(&String::from_utf8_lossy(&output.stdout))
 }
 
 /// Binary ids of every test nextest selects under `expr`.
 fn binaries_selected_by(expr: &str) -> BTreeSet<String> {
-    let (stdout, _) = nextest_list(expr);
     // Non-interactive listing prints one line per test: "<binary-id> <test name>".
     // Test names contain spaces, binary ids do not, so the id is the first field.
-    stdout
+    nextest_stdout(&["list", "-E", expr])
         .lines()
         .filter(|l| !l.trim().is_empty())
         .filter_map(|l| l.split_whitespace().next())
@@ -134,23 +168,17 @@ fn binaries_selected_by(expr: &str) -> BTreeSet<String> {
         .collect()
 }
 
-/// Listing tests must not build anything.
-///
-/// `cargo nextest list` runs every selected binary with `--list`, and the
-/// gauntlet binary used to warm up its Docker fixture from `main()` — so
-/// enumerating tests built an image (issue #20). The guards above evaluate a
-/// filter that selects the gauntlet binary, so a regression here would make
-/// them slow and Docker-dependent rather than cheap.
-#[skuld::test(requires = [nextest_available])]
-fn listing_tests_does_not_build_docker_images() {
-    let filter = slow_timeout_override_filter();
-    let (_, stderr) = nextest_list(&filter);
-    assert!(
-        !stderr.contains("building Docker image"),
-        "listing tests under `{filter}` built a Docker image — enumeration must have no side \
-         effects (issue #20).\nstderr:\n{stderr}"
-    );
+/// Filesystem path of a built test binary, from nextest's own metadata.
+fn test_binary_path(binary_id: &str) -> PathBuf {
+    let json = nextest_stdout(&["list", "--list-type", "binaries-only", "--message-format", "json"]);
+    let doc: serde_json::Value = serde_json::from_str(&json).expect("nextest binaries-only JSON");
+    let path = doc["rust-binaries"][binary_id]["binary-path"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no binary-path for {binary_id} in nextest metadata"));
+    PathBuf::from(path)
 }
+
+// Filter guards -------------------------------------------------------------------------------------------------------
 
 #[skuld::test(requires = [nextest_available])]
 fn slow_timeout_override_covers_every_docker_building_binary() {
@@ -186,5 +214,59 @@ fn gating_job_runs_these_guards() {
         selected.contains("thaum::harness"),
         "the gating CI job's filter `{filter}` does not select `thaum::harness`, so these guards \
          would never run in CI.\nSelected: {selected:?}"
+    );
+}
+
+/// The guards must survive the environment CI actually runs them in.
+///
+/// `ci.yml` sets `CARGO_TERM_COLOR: always` workflow-wide. An earlier version
+/// of this file passed `--color never` to the outer command only, so the inner
+/// `cargo nextest list` inherited the variable and emitted ANSI codes into the
+/// output the assertions parse — and the guards failed in the one job they were
+/// written to protect.
+#[skuld::test(requires = [nextest_available])]
+fn filter_parsing_survives_forced_colour() {
+    let filter = workflow_filter("test");
+    let output = Command::new("cargo")
+        .args(["nextest", "list", "--features", "cli", "-E", &filter])
+        .env("CARGO_TERM_COLOR", "always")
+        .current_dir(project_root())
+        .output()
+        .expect("cargo nextest list");
+    let parsed: BTreeSet<String> = strip_ansi(&String::from_utf8_lossy(&output.stdout))
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_owned)
+        .collect();
+    assert!(
+        parsed.contains("thaum::harness"),
+        "binary ids could not be parsed out of coloured output — the guards would fail in CI, \
+         where CARGO_TERM_COLOR=always.\nParsed: {parsed:?}"
+    );
+}
+
+// Side-effect guard ---------------------------------------------------------------------------------------------------
+
+/// Enumerating tests must build nothing (issue #20).
+///
+/// Asserts against the gauntlet binary's **own stderr**, not against
+/// `cargo nextest list`'s output: nextest discards a test binary's stderr when
+/// listing succeeds, so a guard phrased against the outer command's output can
+/// never fail and reports success forever.
+#[skuld::test(requires = [nextest_available, docker_available], labels = [DOCKER])]
+fn listing_does_not_warm_up_the_docker_fixture() {
+    let binary = test_binary_path("thaum::gauntlet");
+    let output = Command::new(&binary)
+        .arg("--list")
+        .current_dir(project_root())
+        .output()
+        .unwrap_or_else(|e| panic!("running {} --list: {e}", binary.display()));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("building Docker image"),
+        "`{} --list` warmed up the Docker fixture — enumerating tests must have no side effects \
+         (issue #20).\nstderr:\n{stderr}",
+        binary.display()
     );
 }

--- a/tests/infra.rs
+++ b/tests/infra.rs
@@ -2,6 +2,14 @@
 //!
 //! Tests here catch infrastructure problems (Docker, callgrind, binary
 //! availability) independently of functional test suites like gauntlet or parse.
+//!
+//! **These tests run in no CI job.** The gating job excludes `binary(infra)` so
+//! that a required check does not depend on the Docker build cache, and no other
+//! job selects them. They also do not pass unattended even when selected: each
+//! builds an image in its own process, so four builds contend for one daemon and
+//! the per-test timeout is applied to queued work. Both are tracked in #37, which
+//! proposes serialising them with a nextest test group. Run them locally with
+//! `cargo nextest run --features cli -E 'binary(infra)'`.
 
 #[path = "common/mod.rs"]
 mod common;


### PR DESCRIPTION
Closes #20. Addresses the filter half of #9 — see "What this does not fix".

The four Docker-building tests in `tests/infra.rs` matched neither clause of `.config/nextest.toml`'s override — their binary id is `thaum::infra`, not `~gauntlet`, and their names contain `gauntlet`, not `docker` — so they inherited the 30s default. The same tests were selected by the gating CI job's `-E 'not binary(gauntlet)'`, putting Docker builds in a required check.

## Changes

- **`.config/nextest.toml`** — override filter gains `binary_id(~infra)`.
- **`.github/workflows/ci.yml`** — the gating `test` job becomes `-E 'not (binary(gauntlet) | binary(infra))'` and gains `--no-fail-fast`.
- **`tests/gauntlet.rs`** — fixes #20. `main()` warmed up the Docker fixture unconditionally, and `cargo nextest list` runs every binary with `--list`, so *enumerating* tests built an image. Parsing with libtest-mimic's own `Arguments` rather than scanning argv also covers `--help`, which warmed the fixture and then panicked before printing help.
- **`tests/harness.rs`** (new binary) — six guards. They cannot live in `thaum::infra`, which the new gating filter excludes: they would never run in a required job, and a guard asserting `thaum::infra` is unselected while living in it is self-referential.
- **`CONTRIBUTING.md`** — drops `cargo nextest run -P conformance`, which fails with `profile 'conformance' not found`, and documents the Docker-free and host-gauntlet invocations.

### Why `--no-fail-fast`

The interim merge rule while `main` is red (#22) is "no new failures relative to the merge base" — a comparison of two *complete* failing sets, which fail-fast truncates at an arbitrary point. It also closed a real hole: the guards in this PR were broken in CI and reported green, because fail-fast cancelled before `thaum::harness` ran.

It immediately revealed that the pre-existing red is roughly triple what was on record: **Linux 3 → 11, Windows 2 → 7**, including five `dirs`/`pushd`/`popd` failures on Windows that had never been seen and are not TTY/PTY. #22 is being amended.

## What this does not fix

**#9 stays open.** The 120s override does not make those four tests pass: round 1 of this PR ran them with the override applied and all four still timed out, at 240s instead of 60s. The tests are process-scoped fixtures under one process per test, so four image builds contend for one daemon and the per-test timeout is applied to queued work. The eight timeouts disappear from CI here because the tests are no longer *selected*, not because the policy now fits them.

**Those tests now run in no CI job at all** — the gating job excludes `binary(infra)`, `test-gauntlet` excludes it, `coverage` aborts before reaching it, and `bench.yml` runs benchmarks only. On `main`, `not binary(gauntlet)` did include them, so this PR moves them from "runs and times out visibly" to "does not run". That is tracked in **#37**, which proposes the fix: a nextest test group at `max-threads = 1` so the builds serialise rather than contend. An earlier revision of this PR added a `test-docker` job; it was removed because it was permanently red for exactly that reason, and a always-failing job is worse than the misconfiguration it replaces.

## Tests

Six guards in `tests/harness/nextest_config.rs`. Each reads its filter expression from the file that governs it — `.config/nextest.toml`, `.github/workflows/ci.yml`, `CONTRIBUTING.md` — rather than hardcoding it, so a guard cannot drift from what CI actually runs.

| Guard | Property |
| --- | --- |
| `slow_timeout_override_covers_every_docker_building_binary` | every listable image-building binary gets the long timeout |
| `gating_job_selects_no_docker_building_binary` | the required check builds no images |
| `gating_job_runs_these_guards` | the guards are not orphaned by that exclusion |
| `filter_parsing_survives_forced_colour` | parsing works under `CARGO_TERM_COLOR=always`, which `ci.yml` sets workflow-wide |
| `listing_tests_builds_no_image` | regression test for #20 |
| `contributing_documents_the_gating_filter_verbatim` | the documented filter matches the one CI runs |

Every guard was shown failing against the unfixed state before being trusted. Three earlier versions were wrong in ways that made them pass regardless — parsing coloured output as plain, asserting on a stream nextest discards, and asserting a binary exists on a platform where Docker's absence makes it unlistable — so each now carries a positive control, and the #20 guard additionally clears `THAUM_GAUNTLET_NO_SANDBOX` from the child, since an inherited value short-circuits the code path under test.

Full suite before and after: the same 10 pre-existing `thaum::exec` TTY/PTY failures locally, and each platform's CI set matches the `main` baseline by name.
