### PR TITLE
fix(exec): resolve external commands against the shell's PATH

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ See CONTRIBUTING.md for detailed architecture (AST naming, operator precedence, 
   - `compound.rs` — compound command execution (if/while/for/case)
   - `pipeline.rs` — pipeline execution
   - `external.rs` + `command_ex.rs` — external process spawning; `terminal_inherit` enables direct terminal inheritance for interactive programs
+  - `command_lookup.rs` — resolves a command name against the shell's `$PATH` and cwd. Callers resolve before building a `CommandEx`; the spawn layer searches no `PATH` on either platform. An empty `PATH` entry means the cwd, so an absent or empty `PATH` searches the cwd and nothing else — no host environment, no `confstr` default.
   - `redirect.rs` — redirect resolution; `ActiveRedirects` uses save/restore into `IoContext`
   - `subshell.rs` — subshell payload types
   - `numeric.rs` — shared shell-style numeric parsing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,8 @@ src/
     compound.rs        — compound command execution (if/while/for/case)
     pipeline.rs        — pipeline execution
     external.rs        — external process spawning
-    command_ex.rs      — cross-platform Command wrapper (FD mapping)
+    command_ex.rs      — cross-platform Command wrapper (FD mapping); performs no PATH search
+    command_lookup.rs  — command name → executable, using the shell's $PATH and cwd
     redirect.rs        — redirect resolution: opens files, builds ActiveRedirects, save/restore into IoContext
     subshell.rs        — subshell payload types (serialized state)
     numeric.rs         — shared shell-style numeric parsing (hex, octal, char)

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -19,6 +19,8 @@ pub mod buffered_file;
 pub mod builtins;
 mod child_io;
 pub(crate) mod command_ex;
+/// Resolving a command name to an executable using the shell's `$PATH`.
+pub(crate) mod command_lookup;
 mod compound;
 /// Shell state: variables, functions, aliases, positional parameters, CWD, `$?`.
 pub mod environment;
@@ -620,6 +622,21 @@ impl Executor {
                             .map(|(k, v): (String, String)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
                             .collect();
                         child_cmd.fds.insert(1, command_ex::Fd::Pipe);
+
+                        // Command substitution has no IoContext — this site
+                        // does not capture the child's stderr either, so a
+                        // failed lookup sets the status without a diagnostic.
+                        match self.lookup_command(cmd_name, &child_cmd.env) {
+                            Ok(path) => child_cmd.path = path.into_os_string(),
+                            Err(command_lookup::LookupError::NotFound) => {
+                                self.env.set_last_exit_status(127);
+                                continue;
+                            }
+                            Err(command_lookup::LookupError::NotExecutable(_)) => {
+                                self.env.set_last_exit_status(126);
+                                continue;
+                            }
+                        }
 
                         match child_cmd.spawn() {
                             Ok(mut child) => {

--- a/src/exec/command_ex.rs
+++ b/src/exec/command_ex.rs
@@ -2,8 +2,12 @@
 //!
 //! `CommandEx` is a plain data struct describing a child process to spawn.
 //! `ChildEx` is the spawned process handle. `Fd` describes what to do with
-//! each file descriptor. Platform-specific spawn logic uses `posix_spawnp`
+//! each file descriptor. Platform-specific spawn logic uses `posix_spawn`
 //! on Unix and `CreateProcessW` on Windows.
+//!
+//! Neither searches `PATH`: `path` must already name a file. Lookup belongs to
+//! the shell, which resolves against its own `$PATH` in `exec::command_lookup`
+//! before building a `CommandEx`.
 
 use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
@@ -34,7 +38,8 @@ pub(crate) enum Fd {
 /// Description of a child process to spawn. All fields are public; callers
 /// build the struct, then consume it with `spawn(self)`.
 pub(crate) struct CommandEx {
-    /// Executable path for OS lookup (PATH search on both platforms).
+    /// Path to the executable. No `PATH` search is performed — a bare name
+    /// reaching `spawn` is a caller bug.
     pub path: OsString,
     /// Full argv including [0]. Normally `argv[0] == path`.
     /// `exec -a name cmd` sets `argv[0] = "name"` while `path = "cmd"`.
@@ -96,6 +101,15 @@ impl CommandEx {
     }
 
     /// Spawn the child process. Consumes self.
+    ///
+    /// `path` must already name a file: the spawn layer searches no `PATH`.
+    #[contracts::debug_requires(
+        {
+            let p = self.path.to_string_lossy();
+            p.contains('/') || (cfg!(windows) && p.contains('\\'))
+        },
+        "path must be resolved before spawning — see exec::command_lookup"
+    )]
     pub fn spawn(self) -> io::Result<ChildEx> {
         spawn_impl(self)
     }
@@ -308,10 +322,10 @@ fn wait_for_handle(
 // Process replacement =================================================================================================
 
 impl CommandEx {
-    /// Replace the current process image with this command (Unix `execvp`).
+    /// Replace the current process image with this command (Unix `execve`).
     ///
     /// Applies FD redirections via `dup2`, changes CWD, sets environment,
-    /// then calls `execvp`. On success, this function never returns.
+    /// then calls `execve`. On success, this function never returns.
     /// On failure, returns the OS error.
     #[cfg(unix)]
     pub fn exec_replace(self) -> io::Error {
@@ -360,28 +374,9 @@ impl CommandEx {
             .collect::<Result<_, _>>()
             .unwrap_or_default();
 
-        let path_c = match CString::new(self.path.as_bytes()) {
+        let resolved = match CString::new(self.path.as_bytes()) {
             Ok(c) => c,
             Err(e) => return io::Error::new(io::ErrorKind::InvalidInput, e),
-        };
-
-        // Resolve the executable path via PATH if it's a bare name.
-        let resolved = if self.path.to_string_lossy().contains('/') {
-            path_c
-        } else {
-            // Search PATH manually for execve (which doesn't do PATH lookup).
-            let path_var = std::env::var("PATH").unwrap_or_default();
-            let mut found = None;
-            for dir in path_var.split(':') {
-                let candidate = format!("{}/{}", dir, self.path.to_string_lossy());
-                if let Ok(c) = CString::new(candidate.as_bytes()) {
-                    if std::path::Path::new(&candidate).is_file() {
-                        found = Some(c);
-                        break;
-                    }
-                }
-            }
-            found.unwrap_or(path_c)
         };
 
         // execve replaces the process image. Only returns on error.
@@ -826,7 +821,7 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
 
     let mut pid: libc::pid_t = 0;
     let res = unsafe {
-        libc::posix_spawnp(
+        libc::posix_spawn(
             &mut pid,
             path_c.as_ptr(),
             file_actions.as_ptr(),

--- a/src/exec/command_ex/spawn_windows.rs
+++ b/src/exec/command_ex/spawn_windows.rs
@@ -5,7 +5,7 @@
 //! inherit arbitrary file descriptors, not just stdin/stdout/stderr.
 
 use std::collections::HashMap;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 use std::fs::File;
 use std::io;
 use std::os::windows::ffi::OsStrExt;
@@ -23,47 +23,12 @@ use super::{ChildEx, ChildInner, CommandEx, Fd, SendHandle, SendHpcon};
 const FOPEN: u8 = 0x01;
 const FPIPE: u8 = 0x08;
 
-/// Resolve `cmd.path` via PATH + PATHEXT if it's a bare command name.
-///
-/// Equivalent of Unix `posix_spawnp`'s PATH search. `CreateProcessW` does not
-/// search PATH when `lpApplicationName` is non-NULL, so we must do it ourselves.
-fn resolve_path_if_needed(cmd: &mut CommandEx) {
-    let name = cmd.path.to_string_lossy();
-    if name.contains('/') || name.contains('\\') {
-        return;
-    }
-
-    // Use PATH from cmd.env (child's environment) first, falling back to the
-    // process environment. This matches posix_spawnp on Unix, which searches
-    // the calling process's PATH rather than the child's envp.
-    let env_path = cmd
-        .env
-        .get(OsStr::new("PATH"))
-        .and_then(|v| v.to_str())
-        .map(String::from);
-    let proc_path;
-    let path_var = match &env_path {
-        Some(p) => p.as_str(),
-        None => {
-            proc_path = std::env::var("PATH").unwrap_or_default();
-            proc_path.as_str()
-        }
-    };
-
-    let pathext = cmd.env.get(OsStr::new("PATHEXT")).and_then(|v| v.to_str());
-    if let Some(resolved) = super::resolve_windows::resolve_command(cmd.path.as_ref(), path_var, pathext) {
-        cmd.path = resolved.into_os_string();
-    }
-}
-
 /// Spawn a child process using `CreateProcessW` with full fd table support.
 ///
 /// If any fd is `Fd::Pty`, delegates to `spawn_with_conpty` for terminal
 /// emulation. Mixed cases (only stdout or only stderr needing a PTY) are
 /// handled by ConPTY with explicit `hStd*` overrides for the non-PTY fd.
-pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
-    resolve_path_if_needed(&mut cmd);
-
+pub(super) fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     let any_pty = cmd.fds.values().any(|fd| matches!(fd, Fd::Pty));
     if any_pty {
         return spawn_with_conpty(cmd);

--- a/src/exec/command_lookup.rs
+++ b/src/exec/command_lookup.rs
@@ -1,0 +1,197 @@
+//! Resolving a command name to an executable using the shell's own `$PATH`.
+//!
+//! Lookup is shell state, not process state: it reads the `PATH` variable of
+//! the running shell (exported or not), resolves relative and empty entries
+//! against the shell's cwd, and produces the 126/127 statuses the shell
+//! reports. The spawn layer receives an already-resolved path and searches
+//! nothing.
+//!
+//! An absent or empty `PATH` is a single empty entry, which means the shell's
+//! cwd (POSIX XBD 8.3) — so `PATH=; cmd` still runs `cmd` from the cwd, but
+//! reaches nothing else.
+//!
+//! That "nothing else" is not an assumption; it is forced by a pair of measured
+//! results. In bash 5.3 under `env -i`, `unset PATH; ls` fails with 127 while
+//! `unset PATH; ./tool-in-cwd` runs. If an unset `PATH` fell back to the host
+//! environment or to `confstr(_CS_PATH)`, `ls` would have been found; if it
+//! searched nothing at all, the cwd tool would not have been. Only "the cwd,
+//! and solely the cwd" satisfies both. Bash reserves the `confstr` default for
+//! `command -p`, which thaum does not implement.
+//!
+//! Beware of confirming this with a probe whose cwd lacks the tool: an
+//! empty-`PATH`-means-cwd shell and an empty-`PATH`-fails shell both answer 127
+//! there, so such a probe distinguishes nothing.
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::exec::io_context::IoContext;
+use crate::exec::Executor;
+
+/// Why a command name could not be turned into something spawnable.
+#[derive(Debug)]
+pub(crate) enum LookupError {
+    /// No candidate matched, or `PATH` was absent or empty.
+    NotFound,
+    /// A regular file matched but is not executable. Carries the first such
+    /// candidate — the one bash names in its diagnostic.
+    ///
+    /// Never produced on Windows, which has no execute bit: a file that does
+    /// not match `PATHEXT` is simply not a candidate.
+    #[cfg_attr(windows, allow(dead_code))]
+    NotExecutable(PathBuf),
+}
+
+/// Separator between `PATH` entries.
+const PATH_SEPARATOR: char = if cfg!(windows) { ';' } else { ':' };
+
+/// Whether `name` denotes a path rather than a bare command name.
+fn has_path_separator(name: &str) -> bool {
+    name.contains('/') || (cfg!(windows) && name.contains('\\'))
+}
+
+/// Whether `path` is a regular file that may be executed.
+///
+/// Directories are excluded even though they carry the execute bit. On Windows
+/// there is no execute bit; executability is decided by extension, which
+/// `resolve_windows` handles when it generates candidates.
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+}
+
+/// Whether `path` is a regular file, executable or not.
+#[cfg(not(windows))]
+fn is_regular_file(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|m| m.is_file())
+}
+
+/// Turn one `PATH` entry into a directory, resolving it against the shell's
+/// cwd. An empty entry means the cwd, as does any relative entry.
+///
+/// The empty case is load-bearing, not decorative: an empty or absent `PATH`
+/// splits into exactly one empty entry, so this branch is what makes
+/// `PATH=; cmd` and `unset PATH; cmd` search the cwd the way bash does. It is
+/// spelled out rather than left to the relative branch, where correctness would
+/// rest on `Path::join("")` incidentally yielding an unchanged path.
+fn entry_to_dir(entry: &str, cwd: &Path) -> PathBuf {
+    if entry.is_empty() {
+        return cwd.to_path_buf();
+    }
+    let p = Path::new(entry);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        cwd.join(p)
+    }
+}
+
+/// Resolve `name` to an executable path.
+///
+/// A `name` containing a path separator is returned unchanged: bash performs no
+/// `PATH` search for it, and the caller spawns it relative to the shell's cwd.
+/// `pathext` is the shell's `PATHEXT` and is consulted on Windows only.
+#[cfg_attr(debug_assertions, contracts::debug_ensures(
+    has_path_separator(name) || ret.as_ref().is_ok_and(|p| p.is_absolute()) || ret.is_err(),
+    "a searched name must resolve to an absolute path"
+))]
+#[cfg_attr(not(windows), allow(unused_variables))]
+pub(crate) fn resolve(
+    name: &str,
+    path_var: Option<&str>,
+    cwd: &Path,
+    pathext: Option<&str>,
+) -> Result<PathBuf, LookupError> {
+    if has_path_separator(name) {
+        return Ok(PathBuf::from(name));
+    }
+
+    // An absent `PATH` is treated as an empty one, which splits into a single
+    // empty entry — i.e. the shell's cwd, and nothing else. There is no fallback
+    // to the host environment or to `confstr(_CS_PATH)`.
+    let path_var = path_var.unwrap_or("");
+
+    let dirs: Vec<PathBuf> = path_var.split(PATH_SEPARATOR).map(|e| entry_to_dir(e, cwd)).collect();
+
+    #[cfg(windows)]
+    {
+        // Windows candidate generation (PATHEXT modes) lives in
+        // `resolve_windows`; feed it directories already resolved against the
+        // shell's cwd.
+        let absolute = dirs
+            .iter()
+            .map(|d| d.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(";");
+        return match crate::exec::command_ex::resolve_windows::resolve_command(OsStr::new(name), &absolute, pathext) {
+            Some(p) => Ok(p),
+            None => Err(LookupError::NotFound),
+        };
+    }
+
+    #[cfg(not(windows))]
+    {
+        let mut first_non_executable = None;
+        for dir in &dirs {
+            let candidate = dir.join(name);
+            if is_executable_file(&candidate) {
+                return Ok(candidate);
+            }
+            if first_non_executable.is_none() && is_regular_file(&candidate) {
+                first_non_executable = Some(candidate);
+            }
+        }
+        match first_non_executable {
+            Some(p) => Err(LookupError::NotExecutable(p)),
+            None => Err(LookupError::NotFound),
+        }
+    }
+}
+
+/// Write the shell's diagnostic for `err` and return the exit status it implies.
+///
+/// A missing command is 127 and names what the user typed; an unusable match is
+/// 126 and names the file that was rejected, since that identifies which `PATH`
+/// entry produced it.
+pub(crate) fn report(err: &LookupError, name: &str, io: &mut IoContext) -> i32 {
+    match err {
+        LookupError::NotFound => {
+            if let Some(stderr) = io.fd_mut(2) {
+                let _ = writeln!(stderr, "{name}: command not found");
+            }
+            127
+        }
+        LookupError::NotExecutable(path) => {
+            if let Some(stderr) = io.fd_mut(2) {
+                let _ = writeln!(stderr, "{}: Permission denied", path.display());
+            }
+            126
+        }
+    }
+}
+
+impl Executor {
+    /// Resolve `name` for a child process whose environment is `child_env`.
+    ///
+    /// `child_env` holds the exported variables plus this command's prefix
+    /// assignments, so `PATH=dir cmd` searches `dir` for `cmd` itself. When it
+    /// carries no `PATH`, the shell variable is used — bash honours `PATH` for
+    /// lookup whether or not it was exported.
+    pub(crate) fn lookup_command(
+        &self,
+        name: &str,
+        child_env: &HashMap<OsString, OsString>,
+    ) -> Result<PathBuf, LookupError> {
+        let from_child = |key: &str| child_env.get(OsStr::new(key)).and_then(|v| v.to_str());
+        let path_var = from_child("PATH").or_else(|| self.env.get_var("PATH"));
+        let pathext = from_child("PATHEXT").or_else(|| self.env.get_var("PATHEXT"));
+        resolve(name, path_var, self.env.cwd(), pathext)
+    }
+}
+
+#[cfg(test)]
+#[path = "command_lookup_tests.rs"]
+mod tests;

--- a/src/exec/command_lookup_tests.rs
+++ b/src/exec/command_lookup_tests.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use skuld::temp_dir;
+
+use super::{report, resolve, LookupError};
+use crate::exec::io_context::CapturedIo;
+use crate::exec::{Environment, Executor};
+use crate::test_labels::EXEC;
+
+skuld::default_labels!(EXEC);
+
+/// Create an executable file at `path`. On Unix the execute bits are set; on
+/// Windows executability is decided by extension, so mode is irrelevant.
+fn write_executable(path: &Path) {
+    std::fs::write(path, b"").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+/// Create a regular file that is not executable.
+#[cfg(unix)]
+fn write_non_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::write(path, b"").unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+}
+
+/// Join directories into a `PATH` string using the platform separator.
+fn path_var(dirs: &[&Path]) -> String {
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    dirs.iter()
+        .map(|d| d.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join(sep)
+}
+
+/// Name of the command under test, with the extension Windows needs to
+/// consider a file executable.
+fn cmd_name() -> &'static str {
+    if cfg!(windows) {
+        "mytool.exe"
+    } else {
+        "mytool"
+    }
+}
+
+fn mkdir(parent: &Path, name: &str) -> PathBuf {
+    let d = parent.join(name);
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+// Names that bypass the search ========================================================================================
+
+#[skuld::test]
+fn name_with_separator_is_returned_unsearched(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    write_executable(&a.join(cmd_name()));
+
+    // The name has a separator, so `PATH` is irrelevant — even a `PATH` that
+    // contains a match must not redirect it.
+    let result = resolve("./sub/mytool", Some(&path_var(&[&a])), dir, None).unwrap();
+    assert_eq!(result, PathBuf::from("./sub/mytool"));
+}
+
+// Search order ========================================================================================================
+
+#[skuld::test]
+fn first_executable_match_wins(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    let b = mkdir(dir, "b");
+    write_executable(&a.join(cmd_name()));
+    write_executable(&b.join(cmd_name()));
+
+    let result = resolve(cmd_name(), Some(&path_var(&[&a, &b])), dir, None).unwrap();
+    assert_eq!(result, a.join(cmd_name()));
+}
+
+#[skuld::test]
+fn no_match_anywhere_is_not_found(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    let err = resolve(cmd_name(), Some(&path_var(&[&a])), dir, None).unwrap_err();
+    assert!(matches!(err, LookupError::NotFound), "expected NotFound");
+}
+
+#[skuld::test]
+fn directory_match_is_skipped(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    let b = mkdir(dir, "b");
+    // A *directory* named like the command must never match, even though
+    // directories carry the execute bit.
+    mkdir(&a, cmd_name());
+    write_executable(&b.join(cmd_name()));
+
+    let result = resolve(cmd_name(), Some(&path_var(&[&a, &b])), dir, None).unwrap();
+    assert_eq!(result, b.join(cmd_name()));
+
+    let err = resolve(cmd_name(), Some(&path_var(&[&a])), dir, None).unwrap_err();
+    assert!(matches!(err, LookupError::NotFound), "expected NotFound");
+}
+
+// Non-executable matches ==============================================================================================
+
+#[cfg(unix)]
+#[skuld::test]
+fn search_continues_past_non_executable_match(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    let b = mkdir(dir, "b");
+    write_non_executable(&a.join(cmd_name()));
+    write_executable(&b.join(cmd_name()));
+
+    let result = resolve(cmd_name(), Some(&path_var(&[&a, &b])), dir, None).unwrap();
+    assert_eq!(result, b.join(cmd_name()));
+}
+
+#[cfg(unix)]
+#[skuld::test]
+fn only_non_executable_match_is_not_executable_error(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    write_non_executable(&a.join(cmd_name()));
+
+    match resolve(cmd_name(), Some(&path_var(&[&a])), dir, None) {
+        Err(LookupError::NotExecutable(p)) => assert_eq!(p, a.join(cmd_name())),
+        other => panic!("expected NotExecutable, got {:?}", other.is_ok()),
+    }
+}
+
+#[cfg(unix)]
+#[skuld::test]
+fn first_non_executable_is_the_one_reported(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    let b = mkdir(dir, "b");
+    write_non_executable(&a.join(cmd_name()));
+    write_non_executable(&b.join(cmd_name()));
+
+    match resolve(cmd_name(), Some(&path_var(&[&a, &b])), dir, None) {
+        Err(LookupError::NotExecutable(p)) => assert_eq!(p, a.join(cmd_name())),
+        other => panic!("expected NotExecutable, got {:?}", other.is_ok()),
+    }
+}
+
+// Absent and empty PATH ===============================================================================================
+
+// An empty `PATH` is a single empty entry, and an empty entry means the current
+// directory (POSIX XBD 8.3). An unset `PATH` behaves identically. Neither falls
+// back to the host environment or to `confstr(_CS_PATH)` — measured in bash 5.3
+// under `env -i`, where `unset PATH; ls` is 127 but `unset PATH; ./tool-in-cwd`
+// runs.
+
+#[skuld::test]
+fn absent_path_var_searches_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    write_executable(&cwd.join(cmd_name()));
+
+    let result = resolve(cmd_name(), None, &cwd, None).unwrap();
+    assert_eq!(result, cwd.join(cmd_name()));
+}
+
+#[skuld::test]
+fn empty_path_var_searches_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    write_executable(&cwd.join(cmd_name()));
+
+    let result = resolve(cmd_name(), Some(""), &cwd, None).unwrap();
+    assert_eq!(result, cwd.join(cmd_name()));
+}
+
+#[skuld::test]
+fn absent_path_var_does_not_reach_beyond_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    let elsewhere = mkdir(dir, "elsewhere");
+    write_executable(&elsewhere.join(cmd_name()));
+
+    // Only the cwd is searched — no host `PATH`, no `confstr` default.
+    let err = resolve(cmd_name(), None, &cwd, None).unwrap_err();
+    assert!(matches!(err, LookupError::NotFound), "expected NotFound");
+    let err = resolve(cmd_name(), Some(""), &cwd, None).unwrap_err();
+    assert!(matches!(err, LookupError::NotFound), "expected NotFound");
+}
+
+// PATH entries resolved against the shell's cwd =======================================================================
+
+#[skuld::test]
+fn empty_path_entry_means_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    let other = mkdir(dir, "other");
+    write_executable(&cwd.join(cmd_name()));
+
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let leading = format!("{sep}{}", other.to_string_lossy());
+    let trailing = format!("{}{sep}", other.to_string_lossy());
+    let doubled = format!("{}{sep}{sep}{}", other.to_string_lossy(), other.to_string_lossy());
+
+    for var in [leading, trailing, doubled] {
+        let result = resolve(cmd_name(), Some(&var), &cwd, None)
+            .unwrap_or_else(|_| panic!("empty entry in {var:?} should resolve to cwd"));
+        assert_eq!(result, cwd.join(cmd_name()));
+    }
+}
+
+#[skuld::test]
+fn relative_path_entry_resolves_against_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    let tools = mkdir(dir, "tools");
+    write_executable(&tools.join(cmd_name()));
+
+    // `../tools` is relative to the *shell's* cwd, not the process cwd.
+    let result = resolve(cmd_name(), Some("../tools"), &cwd, None).unwrap();
+    assert_eq!(result, cwd.join("../tools").join(cmd_name()));
+}
+
+#[skuld::test]
+fn dot_path_entry_means_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    write_executable(&cwd.join(cmd_name()));
+
+    let result = resolve(cmd_name(), Some("."), &cwd, None).unwrap();
+    assert_eq!(result, cwd.join(".").join(cmd_name()));
+}
+
+// Which PATH the shell uses ===========================================================================================
+
+/// An executor whose cwd is `cwd` and whose shell `PATH` is `path`.
+fn executor_with(path: Option<&str>, cwd: &Path) -> Executor {
+    let mut env = Environment::new();
+    env.set_cwd(cwd.to_path_buf()).unwrap();
+    if let Some(p) = path {
+        env.set_var("PATH", p).unwrap();
+    }
+    Executor::with_env(env)
+}
+
+fn child_env(pairs: &[(&str, &str)]) -> HashMap<OsString, OsString> {
+    pairs
+        .iter()
+        .map(|(k, v)| (OsString::from(k), OsString::from(v)))
+        .collect()
+}
+
+#[skuld::test]
+fn unexported_shell_path_is_used_when_child_env_has_none(#[fixture(temp_dir)] dir: &Path) {
+    let a = mkdir(dir, "a");
+    write_executable(&a.join(cmd_name()));
+
+    // `set_var` does not export, so `PATH` never reaches the child environment.
+    // Lookup must use it anyway.
+    let executor = executor_with(Some(&path_var(&[&a])), dir);
+    let result = executor.lookup_command(cmd_name(), &child_env(&[])).unwrap();
+    assert_eq!(result, a.join(cmd_name()));
+}
+
+#[skuld::test]
+fn prefix_assignment_path_overrides_shell_variable(#[fixture(temp_dir)] dir: &Path) {
+    let shell_dir = mkdir(dir, "shell");
+    let prefix_dir = mkdir(dir, "prefix");
+    write_executable(&shell_dir.join(cmd_name()));
+    write_executable(&prefix_dir.join(cmd_name()));
+
+    // `PATH=<prefix_dir> mytool` must find `mytool` in `prefix_dir`.
+    let executor = executor_with(Some(&path_var(&[&shell_dir])), dir);
+    let env = child_env(&[("PATH", &path_var(&[&prefix_dir]))]);
+    let result = executor.lookup_command(cmd_name(), &env).unwrap();
+    assert_eq!(result, prefix_dir.join(cmd_name()));
+}
+
+#[skuld::test]
+fn shell_without_path_variable_searches_cwd(#[fixture(temp_dir)] dir: &Path) {
+    let cwd = mkdir(dir, "cwd");
+    write_executable(&cwd.join(cmd_name()));
+    let executor = executor_with(None, &cwd);
+    let result = executor.lookup_command(cmd_name(), &child_env(&[])).unwrap();
+    assert_eq!(result, cwd.join(cmd_name()));
+}
+
+// Diagnostics =========================================================================================================
+
+/// Run `report` against a captured `IoContext` and return `(status, stderr)`.
+fn captured_report(err: &LookupError, name: &str) -> (i32, String) {
+    let (mut io, capture) = CapturedIo::new();
+    let status = report(err, name, &mut io);
+    let output = capture.finish(io);
+    (status, output.stderr_string())
+}
+
+#[skuld::test]
+fn report_not_found_writes_command_not_found_and_returns_127() {
+    let (status, stderr) = captured_report(&LookupError::NotFound, "mytool");
+    assert_eq!(status, 127);
+    assert_eq!(stderr, "mytool: command not found\n");
+}
+
+#[skuld::test]
+fn report_not_executable_names_the_resolved_path_and_returns_126() {
+    // bash names the rejected file, not the typed name: the path is what
+    // identifies which `PATH` entry produced the unusable match.
+    let err = LookupError::NotExecutable(PathBuf::from("/tools/mytool"));
+    let (status, stderr) = captured_report(&err, "mytool");
+    assert_eq!(status, 126);
+    assert_eq!(stderr, "/tools/mytool: Permission denied\n");
+}

--- a/src/exec/external.rs
+++ b/src/exec/external.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 
 use crate::exec::child_io;
 use crate::exec::command_ex::{CommandEx, Fd};
+use crate::exec::command_lookup;
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::redirect::ActiveRedirects;
@@ -52,6 +53,13 @@ impl Executor {
             env.insert(assignment.name.clone().into(), value.into());
         }
         child_cmd.env = env;
+
+        // Resolve the command against the shell's PATH before spawning: the
+        // spawn layer searches nothing.
+        match self.lookup_command(name, &child_cmd.env) {
+            Ok(path) => child_cmd.path = path.into_os_string(),
+            Err(e) => return Ok(command_lookup::report(&e, name, io)),
+        }
 
         // IoContext FDs (3+) — includes persistent fds from `exec` redirects.
         for (&fd, file) in io.fds() {
@@ -114,7 +122,7 @@ impl Executor {
             }
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                 if let Some(stderr) = io.fd_mut(2) {
-                    let _ = writeln!(stderr, "{name}: permission denied");
+                    let _ = writeln!(stderr, "{name}: Permission denied");
                 }
                 Ok(126)
             }

--- a/src/exec/pipeline.rs
+++ b/src/exec/pipeline.rs
@@ -175,6 +175,14 @@ fn spawn_pipeline_stage(
                 child_cmd.env.insert(assignment.name.clone().into(), value.into());
             }
 
+            match executor.lookup_command(cmd_name, &child_cmd.env) {
+                Ok(path) => child_cmd.path = path.into_os_string(),
+                Err(e) => {
+                    let status = crate::exec::command_lookup::report(&e, cmd_name, io);
+                    return Ok(Some(ChildEx::completed(status, std::collections::HashMap::new())));
+                }
+            }
+
             for (&fd, file) in io.fds() {
                 if fd >= 3 {
                     child_cmd
@@ -219,7 +227,7 @@ fn spawn_pipeline_stage(
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                     if let Some(stderr) = io.fd_mut(2) {
-                        let _ = writeln!(stderr, "{cmd_name}: permission denied");
+                        let _ = writeln!(stderr, "{cmd_name}: Permission denied");
                     }
                     Ok(Some(ChildEx::completed(126, std::collections::HashMap::new())))
                 }

--- a/src/exec/special_builtins.rs
+++ b/src/exec/special_builtins.rs
@@ -165,6 +165,22 @@ impl Executor {
             .map(|(k, v)| (k.into(), v.into()))
             .collect();
 
+        match self.lookup_command(cmd_name, &cmd.env) {
+            Ok(path) => cmd.path = path.into_os_string(),
+            // bash words a missing `exec` target as "exec: NAME: not found",
+            // but reports an unusable one exactly as ordinary lookup does.
+            Err(crate::exec::command_lookup::LookupError::NotFound) => {
+                if let Some(stderr) = io.fd_mut(2) {
+                    let _ = writeln!(stderr, "exec: {cmd_name}: not found");
+                }
+                return Err(ExecError::ExitRequested(127));
+            }
+            Err(e) => {
+                let status = crate::exec::command_lookup::report(&e, cmd_name, io);
+                return Err(ExecError::ExitRequested(status));
+            }
+        }
+
         // Build FD table: IoContext fds 3+ first, per-command redirects override.
         for (&fd, file) in io.fds() {
             if fd >= 3 {
@@ -213,19 +229,6 @@ impl Executor {
 
         #[cfg(not(unix))]
         {
-            // Resolve command via PATH + PATHEXT on Windows (CreateProcessW
-            // does not search PATH when lpApplicationName is non-NULL).
-            #[cfg(windows)]
-            if !cmd_name.contains('/') && !cmd_name.contains('\\') {
-                let path_var = self.env.get_var("PATH").unwrap_or("");
-                let pathext = self.env.get_var("PATHEXT");
-                if let Some(resolved) =
-                    crate::exec::command_ex::resolve_windows::resolve_command(cmd_name.as_ref(), path_var, pathext)
-                {
-                    cmd.path = resolved.into_os_string();
-                }
-            }
-
             match cmd.spawn() {
                 Ok(mut child) => {
                     let code = child.wait().map_err(ExecError::Io)?;

--- a/tests/exec.rs
+++ b/tests/exec.rs
@@ -381,6 +381,8 @@ mod expansion;
 mod external;
 #[path = "exec/interactive.rs"]
 mod interactive;
+#[path = "exec/path_lookup.rs"]
+mod path_lookup;
 #[path = "exec/printf.rs"]
 mod printf;
 #[path = "exec/variables.rs"]

--- a/tests/exec/path_lookup.rs
+++ b/tests/exec/path_lookup.rs
@@ -1,0 +1,418 @@
+//! Tests for external command lookup against the shell's own `$PATH`.
+//!
+//! Every expected value here was measured against GNU bash 5.3.15 before the
+//! test was written.
+//!
+//! Commands are identified by **exit status**: two `test_tools` binaries,
+//! `true` (0) and `false` (1), are copied into different directories under the
+//! same name, so "which file ran" is a single assertion that needs no shell
+//! scripts, no output parsing, and no platform-specific fixtures. Neither
+//! status collides with the 126 and 127 these tests also assert.
+
+use std::path::{Path, PathBuf};
+
+use crate::*;
+
+/// Platform executable name. On Windows the planted file needs an extension;
+/// with `PATHEXT` unset the resolver tries the bare name and then `.exe`, so
+/// scripts can still invoke it as `mytool`.
+fn exe(name: &str) -> String {
+    if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    }
+}
+
+/// Copy the `test_tools` binary `source` into `dir` under `name`.
+///
+/// A copy, not a link: each planted file must be a distinct executable so that
+/// the directory it lives in is what decides which one runs.
+fn plant(tools: &Path, source: &str, dir: &Path, name: &str) -> PathBuf {
+    std::fs::create_dir_all(dir).unwrap();
+    let dst = dir.join(exe(name));
+    std::fs::copy(tools.join(exe(source)), &dst).unwrap_or_else(|e| panic!("copy {source} -> {}: {e}", dst.display()));
+    dst
+}
+
+/// Render a path for embedding in a shell script.
+fn s(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+/// Separator between `PATH` entries. Windows uses `;` because `:` appears in
+/// drive-letter paths.
+fn sep() -> &'static str {
+    if cfg!(windows) {
+        ";"
+    } else {
+        ":"
+    }
+}
+
+/// Join directories into a `PATH` value.
+fn path_of(dirs: &[&Path]) -> String {
+    dirs.iter().map(|d| s(d)).collect::<Vec<_>>().join(sep())
+}
+
+// Which binary the shell's PATH selects ===============================================================================
+
+#[skuld::test]
+fn lookup_shell_path_selects_between_same_named_binaries(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    let losing = dir.join("losing");
+    let winning = dir.join("winning");
+    plant(tools, "false", &losing, "mytool");
+    plant(tools, "true", &winning, "mytool");
+
+    // Both directories are on PATH; the earlier one must win, and the host
+    // environment must not get a vote.
+    let path = path_of(&[&winning, &losing]);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0, "the first PATH entry's binary should run");
+
+    let path = path_of(&[&losing, &winning]);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 1, "reordering PATH should change which binary runs");
+}
+
+#[skuld::test]
+fn lookup_path_excluding_tool_makes_it_not_found(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let hidden = dir.join("hidden");
+    let empty = dir.join("empty");
+    plant(tools, "true", &hidden, "mytool");
+    std::fs::create_dir_all(&empty).unwrap();
+
+    // The tool exists, but not on the PATH the shell set. A shell that falls
+    // back to the host environment would find it anyway; bash does not.
+    let path = s(&empty);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "mytool: command not found\n");
+}
+
+#[skuld::test]
+fn lookup_missing_command_is_127(#[fixture(test_tools)] tools: &Path) {
+    let tools_dir = tools.to_string_lossy();
+    let r = exec!("no_such_tool_xyz", env = &[("PATH", &*tools_dir)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "no_such_tool_xyz: command not found\n");
+}
+
+// Absent and empty PATH ===============================================================================================
+
+// An empty `PATH` is a single empty entry, and an empty entry means the current
+// directory (POSIX XBD 8.3); an unset `PATH` behaves identically. So the cwd is
+// searched — but nothing else: no host `PATH`, and no `confstr(_CS_PATH)`
+// default, which bash reserves for `command -p`.
+
+#[skuld::test]
+fn lookup_unset_path_searches_cwd(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let here = dir.join("here");
+    plant(tools, "true", &here, "mytool");
+
+    let script = format!("cd {}; unset PATH; mytool", s(&here));
+    let start = s(dir);
+    let r = exec!(&*script, env = &[("PATH", &*start)]);
+    assert_eq!(r.status(), 0, "unset PATH should still resolve against the cwd");
+}
+
+#[skuld::test]
+fn lookup_empty_path_searches_cwd(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let here = dir.join("here");
+    plant(tools, "true", &here, "mytool");
+
+    let script = format!("cd {}; PATH=; mytool", s(&here));
+    let start = s(dir);
+    let r = exec!(&*script, env = &[("PATH", &*start)]);
+    assert_eq!(r.status(), 0, "empty PATH should still resolve against the cwd");
+}
+
+#[skuld::test]
+fn lookup_unset_path_does_not_reach_beyond_cwd(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let bin = dir.join("bin");
+    let here = dir.join("here");
+    plant(tools, "true", &bin, "mytool");
+    std::fs::create_dir_all(&here).unwrap();
+
+    // `mytool` exists, but not in the cwd — and there is nowhere else to look.
+    let script = format!("cd {}; unset PATH; mytool", s(&here));
+    let start = s(&bin);
+    let r = exec!(&*script, env = &[("PATH", &*start)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "mytool: command not found\n");
+}
+
+#[skuld::test]
+fn lookup_empty_path_does_not_reach_beyond_cwd(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let bin = dir.join("bin");
+    let here = dir.join("here");
+    plant(tools, "true", &bin, "mytool");
+    std::fs::create_dir_all(&here).unwrap();
+
+    let script = format!("cd {}; PATH=; mytool", s(&here));
+    let start = s(&bin);
+    let r = exec!(&*script, env = &[("PATH", &*start)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "mytool: command not found\n");
+}
+
+// PATH need not be exported ===========================================================================================
+
+#[skuld::test]
+fn lookup_unexported_path_is_used(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let bin = dir.join("bin");
+    plant(tools, "env", &bin, "showenv");
+
+    // `exec!` sets PATH as a plain shell variable, so it is never exported and
+    // never reaches the child's environment — yet lookup must still use it.
+    let path = s(&bin);
+    let r = exec!("showenv", env = &[("PATH", &*path)]);
+    let out = r.stdout();
+    assert!(
+        !out.contains("PATH="),
+        "PATH should not have been exported to the child, got: {out}"
+    );
+}
+
+#[skuld::test]
+fn lookup_prefix_assignment_applies_to_its_own_command(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    let shell_dir = dir.join("shell");
+    let prefix_dir = dir.join("prefix");
+    plant(tools, "false", &shell_dir, "mytool");
+    plant(tools, "true", &prefix_dir, "mytool");
+
+    // `PATH=<dir> mytool` uses <dir> to find `mytool` itself.
+    let script = format!("PATH={} mytool", s(&prefix_dir));
+    let path = s(&shell_dir);
+    let r = exec!(&*script, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+}
+
+// PATH entries resolved against the shell's cwd =======================================================================
+
+#[skuld::test]
+fn lookup_relative_path_entry_resolves_against_shell_cwd(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    let start = dir.join("start");
+    let sibling = dir.join("sibling");
+    std::fs::create_dir_all(&start).unwrap();
+    plant(tools, "true", &sibling, "mytool");
+
+    // `../sibling` is relative to the shell's cwd after `cd`, not to the cwd of
+    // the process hosting the shell.
+    let script = format!("cd {}; PATH=../sibling; mytool", s(&start));
+    let empty = s(dir);
+    let r = exec!(&*script, env = &[("PATH", &*empty)]);
+    assert_eq!(r.status(), 0);
+}
+
+#[skuld::test]
+fn lookup_empty_path_entry_means_cwd(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let here = dir.join("here");
+    let elsewhere = dir.join("elsewhere");
+    plant(tools, "true", &here, "mytool");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+
+    // A leading empty entry means the shell's cwd.
+    let script = format!("cd {}; PATH={}{}; mytool", s(&here), sep(), s(&elsewhere));
+    let start = s(&elsewhere);
+    let r = exec!(&*script, env = &[("PATH", &*start)]);
+    assert_eq!(r.status(), 0);
+}
+
+// Unusable matches ====================================================================================================
+
+#[cfg(unix)]
+#[skuld::test]
+fn lookup_non_executable_match_is_126(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let bin = dir.join("bin");
+    let planted = plant(tools, "true", &bin, "mytool");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let path = s(&bin);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 126);
+    assert_eq!(r.stderr(), format!("{}: Permission denied\n", planted.display()));
+}
+
+#[cfg(unix)]
+#[skuld::test]
+fn lookup_search_continues_past_non_executable_match(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    use std::os::unix::fs::PermissionsExt;
+    let unusable = dir.join("unusable");
+    let usable = dir.join("usable");
+    let planted = plant(tools, "false", &unusable, "mytool");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o644)).unwrap();
+    plant(tools, "true", &usable, "mytool");
+
+    // A non-executable match does not end the search.
+    let path = path_of(&[&unusable, &usable]);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+}
+
+#[skuld::test]
+fn lookup_directory_named_like_command_is_skipped(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    let shadow = dir.join("shadow");
+    let real = dir.join("real");
+    std::fs::create_dir_all(shadow.join(exe("mytool"))).unwrap();
+    plant(tools, "true", &real, "mytool");
+
+    // Directories carry the execute bit but are never commands.
+    let path = path_of(&[&shadow, &real]);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+
+    let path = s(&shadow);
+    let r = exec!("mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "mytool: command not found\n");
+}
+
+// Every spawn site uses the same lookup ===============================================================================
+
+#[skuld::test]
+fn lookup_applies_in_pipeline_stage(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let chosen = dir.join("chosen");
+    let decoy = dir.join("decoy");
+    plant(tools, "true", &chosen, "mytool");
+    plant(tools, "false", &decoy, "mytool");
+
+    // A pipeline stage resolves through the same shell PATH as a plain command.
+    // `mytool` is the last stage because a pipeline's status is the last
+    // stage's; `echo` is a builtin and needs no lookup.
+    let path = path_of(&[&chosen, &decoy]);
+    let r = exec!("echo hi | mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+
+    let path = path_of(&[&decoy, &chosen]);
+    let r = exec!("echo hi | mytool", env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 1);
+}
+
+#[skuld::test]
+fn lookup_pipeline_missing_command_is_127(#[fixture(test_tools)] tools: &Path) {
+    let tools_dir = tools.to_string_lossy();
+    let r = exec!("echo hi | no_such_tool_xyz", env = &[("PATH", &*tools_dir)]);
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "no_such_tool_xyz: command not found\n");
+}
+
+#[skuld::test]
+fn lookup_applies_in_command_substitution(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let chosen = dir.join("chosen");
+    let decoy = dir.join("decoy");
+    plant(tools, "echo", &chosen, "mytool");
+    plant(tools, "false", &decoy, "mytool");
+
+    let path = path_of(&[&chosen, &decoy]);
+    let r = exec!("echo \"[$(mytool picked)]\"", env = &[("PATH", &*path)]);
+    assert_eq!(r.stdout(), "[picked]\n");
+}
+
+#[skuld::test]
+fn lookup_command_substitution_missing_command_is_127(#[fixture(test_tools)] tools: &Path) {
+    let tools_dir = tools.to_string_lossy();
+    let r = exec!("x=$(no_such_tool_xyz); echo \"rc=$?\"", env = &[("PATH", &*tools_dir)]);
+    assert_eq!(r.stdout(), "rc=127\n");
+}
+
+#[skuld::test]
+fn lookup_applies_to_exec_builtin(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let chosen = dir.join("chosen");
+    let decoy = dir.join("decoy");
+    plant(tools, "true", &chosen, "mytool");
+    plant(tools, "false", &decoy, "mytool");
+
+    // Subprocess mode: `exec` replaces the process, which in-process mode
+    // deliberately disallows.
+    let path = path_of(&[&chosen, &decoy]);
+    let r = exec!("exec mytool", mode = ExecMode::Subprocess, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+
+    let path = path_of(&[&decoy, &chosen]);
+    let r = exec!("exec mytool", mode = ExecMode::Subprocess, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 1);
+}
+
+#[skuld::test]
+fn lookup_exec_builtin_missing_command_is_127(#[fixture(test_tools)] tools: &Path) {
+    // bash: "exec: NAME: not found", distinct from ordinary lookup's wording.
+    let tools_dir = tools.to_string_lossy();
+    let r = exec!(
+        "exec no_such_tool_xyz",
+        mode = ExecMode::Subprocess,
+        env = &[("PATH", &*tools_dir)]
+    );
+    assert_eq!(r.status(), 127);
+    assert_eq!(r.stderr(), "exec: no_such_tool_xyz: not found\n");
+}
+
+// Names that are paths ================================================================================================
+
+// A slash-containing name skips the search, so its 126 comes from the spawn
+// errno rather than from lookup. Both routes must word it as bash does —
+// otherwise the same condition reports two different ways depending on which
+// path reached it.
+
+#[cfg(unix)]
+#[skuld::test]
+fn lookup_slash_name_non_executable_is_126(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let sub = dir.join("sub");
+    let planted = plant(tools, "true", &sub, "mytool");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let script = format!("cd {}; ./sub/{}", s(dir), exe("mytool"));
+    let path = s(dir);
+    let r = exec!(&*script, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 126);
+    assert_eq!(r.stderr(), format!("./sub/{}: Permission denied\n", exe("mytool")));
+}
+
+#[cfg(unix)]
+#[skuld::test]
+fn lookup_slash_name_non_executable_in_pipeline_is_126(
+    #[fixture(test_tools)] tools: &Path,
+    #[fixture(temp_dir)] dir: &Path,
+) {
+    use std::os::unix::fs::PermissionsExt;
+    let sub = dir.join("sub");
+    let planted = plant(tools, "true", &sub, "mytool");
+    std::fs::set_permissions(&planted, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let script = format!("cd {}; echo hi | ./sub/{}", s(dir), exe("mytool"));
+    let path = s(dir);
+    let r = exec!(&*script, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 126);
+    assert_eq!(r.stderr(), format!("./sub/{}: Permission denied\n", exe("mytool")));
+}
+
+#[skuld::test]
+fn lookup_name_with_slash_ignores_path(#[fixture(test_tools)] tools: &Path, #[fixture(temp_dir)] dir: &Path) {
+    let sub = dir.join("sub");
+    let decoy = dir.join("decoy");
+    plant(tools, "true", &sub, "mytool");
+    plant(tools, "false", &decoy, "mytool");
+
+    // A name containing a separator is not searched for; PATH is irrelevant.
+    let script = format!("cd {}; ./sub/{}", s(dir), exe("mytool"));
+    let path = s(&decoy);
+    let r = exec!(&*script, env = &[("PATH", &*path)]);
+    assert_eq!(r.status(), 0);
+}


### PR DESCRIPTION
Closes #15. Closes #19.

**macOS goes green: 1597 passed / 10 failed → 1648 passed / 0 failed.** That platform has not had a passing suite since March, and every one of those ten failures was this bug.

Stacked on #35, which is behaviour-neutral prep. Base retargets to `main` when #35 merges.

## The bug

`posix_spawnp` differs from `posix_spawn` in exactly one way: it performs the `PATH` search itself, using the **caller's** environment rather than the `envp` handed to the child. So a script that sets `PATH` got a different binary than every other shell would run, and `PATH=/nonexistent cmd` still succeeded — an embedder could not sandbox by narrowing `PATH`. The same defect had a second Unix site in `exec_replace` (`std::env::var("PATH")`) and a Windows one in `spawn_windows::resolve_path_if_needed`, whose host fallback was justified by a comment pointing at the Unix bug (#19).

## The fix

Lookup is shell state, so it moves to the shell. New `src/exec/command_lookup.rs` resolves a name against the shell's `PATH` variable and cwd; the four `Executor` sites that spawn an external command resolve **before** building a `CommandEx`. The spawn layer then searches nothing on either platform: `posix_spawn` replaces `posix_spawnp`, `exec_replace`'s search is deleted, and `resolve_path_if_needed` is deleted. A `debug_requires` on `CommandEx::spawn` turns a bare name reaching the spawn layer into a loud failure.

Reading the shell **variable** rather than the child's environment matters: bash honours an unexported `PATH` for lookup, and `Environment::set_var` does not export. `child_env["PATH"]` is still consulted first, which is what makes `PATH=dir cmd` find `cmd` in `dir`.

`resolve_windows.rs` is untouched — its `PATHEXT` rules are correct and well covered. `command_lookup` absolutises each `PATH` entry against the shell cwd and hands them to it, so Windows gains cwd-relative entries and loses the host fallback without reimplementing candidate generation.

## Behaviour, measured against GNU bash 5.3.15

Every case below was run against real bash before the corresponding test was written; thaum now matches on all of them.

| Case | Result |
| --- | --- |
| Shell `PATH` selects between same-named binaries | shell's copy runs |
| `PATH` assigned but never exported | still used for lookup |
| `PATH=dir cmd` | `dir` finds `cmd` itself |
| `unset PATH` / `PATH=` | searches the cwd and nothing else (empty entry = cwd); 127 if not there |
| Empty, `.`, or relative `PATH` entry | resolved against the shell's cwd |
| Non-executable match, executable one later | search continues |
| Only non-executable matches | 126, naming the **first** such absolute path |
| Match is a directory | skipped; 127 if nothing else matches |
| Name contains `/` | no search; 126/127 via the spawn errno as before |

`confstr(_CS_PATH)` is deliberately not implemented: bash reserves it for `command -p`, and thaum has no `command` builtin. An empty `PATH` is a *single empty entry*, and an empty entry means the cwd (POSIX XBD 8.3); an unset `PATH` behaves identically. Measured under `env -i` in bash 5.3: `unset PATH; ls` is 127, but `unset PATH; tool-in-cwd` runs — so the cwd is searched and nothing else is. Bash separately *initialises* `$PATH` at startup when absent from the environment — a third, distinct mechanism, also not implemented here.

## User-visible consequences

- **A command excluded by `PATH` is now genuinely not found.** Previously it silently fell through to the host `PATH`. Scripts that relied on that will now see 127 — which is the point.
- **New 126 diagnostic**, naming the rejected absolute path (as bash does) rather than the typed name; the path is what identifies which `PATH` entry produced the unusable match.
- Two residual message-text divergences, both filed as #44 and deliberately left alone here — exit statuses match bash in both:
  - `PATH` unset and the command not found: bash prints `NAME: No such file or directory`, thaum `NAME: command not found` (both 127). Bash skips the search entirely and `execve`s the bare name, surfacing the errno; with an *empty* `PATH` bash itself says `command not found`.
  - A slash-containing name that does not exist: bash `No such file or directory`, thaum `command not found` (both 127).
- **126 now reads the same whichever route produces it.** A slash-containing name skips the search, so its 126 comes from the spawn errno rather than from lookup; that arm said `permission denied` while the new lookup-derived message says `Permission denied`. Since this PR introduced the second wording, both are now bash's `Permission denied`, covered by tests through the simple-command and pipeline paths.

## Tests

40 new tests, all with expected values derived from bash under `env -i`:

- `src/exec/command_lookup_tests.rs` — 17 unit tests over the resolver and the shell-variable precedence rule. Five mutations of `resolve` were checked; four were caught by a named test. The fifth showed the empty-entry branch is redundant (`cwd.join("")` already equals `cwd`) rather than untested — it is kept for explicitness.
- `tests/exec/path_lookup.rs` — 23 integration tests covering every case in the table above plus all four spawn sites. Commands are identified by exit status (`true`/`false` copied under one name), so no shell-script fixtures and no new tool binaries are needed, and 0/1 never collide with the 126/127 the same tests assert.

## Result

Measured per platform with `--no-fail-fast` (CI itself is fail-fast, so its runs abort early and cannot be used for totals — every CI number below is a floor).

The gating filter here is `-E 'not (binary(gauntlet) | binary(infra))'`. `main`'s gating job uses `-E 'not binary(gauntlet)'`, which still admits the four Docker-building `infra` tests; those exceed the 30s slow-timeout on every Docker-capable platform and show up as four timeouts that have nothing to do with this change (#9, fixed by #21). Excluding `binary(infra)` is why no `TIMEOUT` appears below. Once #21 lands the two filters coincide.

| Platform | Before | After |
| --- | --- | --- |
| macOS (local, Darwin 25.6) | 1607 run, 1597 passed, **10 failed** | 1648 run, **1648 passed, 0 failed** |
| Linux (Docker `rust:1-bookworm`) | 1607 run, 1594 passed, **13 failed** | 1642 run, 1633 passed, **9 failed** |

macOS is the headline: **red since March, green here — and confirmed by CI on this head, not just locally.**

The Linux failures are a **strict subset** — nothing regressed. Two of the nine (`test_dash_big_g_checks_group_not_existence`, `test_dash_big_o_checks_ownership_not_existence`) are artifacts of running as root in Docker and do not occur on CI's non-root runner, so the meaningful Linux delta is **11 → 7**.

Fixed on both platforms: the `external_inherit_*` and `external_*_clears_tty` / `external_pipe_stdout_reports_no_tty` group.

The seven survivors are all PTY/ConPTY tests and all fail on `main` too. They are **not** caused by this change — this change makes them *newly diagnosable*: on `main` they fail with status 127 ("command not found", i.e. #15), and here they fail with status 1, because `isatty` is now actually found and executed and the PTY behaviour itself is wrong on Linux. They pass on macOS. That is a separate, Linux-specific defect that #15 was masking.

## CI

- **Lint** — green.
- **Tests (Windows)** — `bash_cond_file_exists` and `bash_cond_file_is_dir`, byte-identical to `main`'s Windows run. Pre-existing and unrelated. **That count of 2 is a fail-fast floor, not a total:** CI runs without `--no-fail-fast`, so the job aborts at 892/1638 and never reaches the new `lookup_*` tests. **Windows coverage of this change is therefore unverified by CI.** It was type- and clippy-checked by cross-compiling (`cargo clippy --target x86_64-pc-windows-msvc --lib --features cli`), which caught one dead-code error that would otherwise have failed the runner.
- **Tests (Linux)** — a floor, and an unstable one: one attempt aborted at 1068/1652 on the three PTY tests (`status 1`, see above), another at 198/1652 on `clean_strips_osc_with_st_terminator` — a pure byte-slice test over `clean_conpty_output` that took 5.08s on a starved runner. It passes locally and in the Docker run, and touches no code this PR changes. The Docker figures above are the complete Linux count.
- **Tests (macOS)** — **green: 1648 run, 1648 passed, 9 skipped**, on this exact head, under `main`'s own gating command `-E 'not binary(gauntlet)'` (which is *stricter* than the filter used for the table above — it still admits `binary(infra)`, whose tests skip on macOS for want of Docker, hence 9 skips rather than 3).
- **Coverage** — 11 → 7 failures, again a strict subset. Runs `cargo test` rather than nextest, so tests share one process; the survivors are the same PTY set.
- **Gauntlet** — failing on `main` as well; `continue-on-error: true` in the workflow.

`main` has had no green CI since March, and it stays red on Linux and Windows after this change — for causes this PR does not claim to fix.
