### PR TITLE
fix(exec): apply `--` redirections and make `>&-` actually close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,10 @@ order *and* on the host's fd table — the failure is nondeterministic and moves
 Actions are then emitted in a fixed order: every dup2, then every close.
 
 On Windows, fds 3+ reach the child only through `build_lpreserved2`, where an absent entry already
-reads as closed. Descriptors 0-2 need an explicit `INVALID_HANDLE_VALUE`, because the
-`STARTF_USESTDHANDLES` block otherwise fills any missing one from the parent's `GetStdHandle`.
+reads as closed. Descriptors 0-2 are **not** closed in the child on Windows: `close_in_child` gates
+them off, so that platform keeps its previous behaviour rather than gaining a change nobody can
+exercise (issue #46). The consequence is a platform divergence, not a new hole — `cmd 1>&-` already
+relayed the child's output to the host's stdout there, and still does.
 
 Closed descriptors 0-2 keep a `/dev/null` substitution for the shell's *own* reads and writes, so
 those succeed where bash reports EBADF (issue #41 — fixing it needs an error path through every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,9 +151,10 @@ held. The distinction matters because thaum is embeddable:
   the same; a child writing to an inherited descriptor is not a bug.
 - **Closed** — the script closed it. It is not resolvable by a later `>&N`, and every child fd
   table gets an `Fd::Close` entry for it. Without that entry `posix_spawn` inherits the number and
-  the child reaches whatever the *host* had there. There are **five** spawn sites: `external.rs`,
-  `pipeline.rs`, the subshell in `exec.rs`, `builtin_exec`, and `execute_command_substitution` —
-  the last is easy to miss because it builds a `CommandEx` from scratch rather than from
+  the child reaches whatever the *host* had there. Rather than count the spawn sites here — a
+  number that has already gone stale once — the rule is that **every site building a child fd table
+  calls `CommandEx::close_fd_in_child`**; `grep` for it to find them. The one that is easy to miss
+  is `execute_command_substitution`, which builds its `CommandEx` from scratch rather than from
   `IoContext`.
 
 thaum never calls `close(2)` on the host's descriptor — it is not thaum's to close. Recording the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,10 @@ held. The distinction matters because thaum is embeddable:
   the same; a child writing to an inherited descriptor is not a bug.
 - **Closed** — the script closed it. It is not resolvable by a later `>&N`, and every child fd
   table gets an `Fd::Close` entry for it. Without that entry `posix_spawn` inherits the number and
-  the child reaches whatever the *host* had there.
+  the child reaches whatever the *host* had there. There are **five** spawn sites: `external.rs`,
+  `pipeline.rs`, the subshell in `exec.rs`, `builtin_exec`, and `execute_command_substitution` —
+  the last is easy to miss because it builds a `CommandEx` from scratch rather than from
+  `IoContext`.
 
 thaum never calls `close(2)` on the host's descriptor — it is not thaum's to close. Recording the
 close and refusing to hand the number out is observably identical for the script and leaves the
@@ -160,9 +163,23 @@ embedder intact.
 `Fd::Close` is implemented as `adddup2(/dev/null, fd)` followed by `addclose(fd)`. A bare
 `addclose` is not usable: if the number is not open, the child's `close(2)` fails and `posix_spawn`
 reports EBADF for the entire spawn (macOS). The dup2 makes the number open unconditionally, with no
-check-then-act against the process-global fd table. On Windows no action is needed — fds 3+ reach
-the child only through `build_lpreserved2`, where an absent entry already reads as closed.
+check-then-act against the process-global fd table.
 
-Closed descriptors 0-2 keep a `/dev/null` substitution for the shell's *own* writes, so those
-succeed where bash reports EBADF (issue #41 — fixing it needs an error path through every
-`io.fd_mut(n)` site). The child half is not deferred: `cmd 1>&-` leaves the child with no stdout.
+**Parent-side source descriptors are relocated above every target before any file action is
+added** (`relocate_above`, `F_DUPFD_CLOEXEC`). The child's actions dup2 *from* parent-side numbers
+and close *at* numbers in `cmd.fds`; if those sets overlap, an action destroys another's input and
+the spawn fails with EBADF. `cmd.fds` is a `HashMap`, so which entries collide depends on iteration
+order *and* on the host's fd table — the failure is nondeterministic and moves with the embedder.
+Actions are then emitted in a fixed order: every dup2, then every close.
+
+On Windows, fds 3+ reach the child only through `build_lpreserved2`, where an absent entry already
+reads as closed. Descriptors 0-2 need an explicit `INVALID_HANDLE_VALUE`, because the
+`STARTF_USESTDHANDLES` block otherwise fills any missing one from the parent's `GetStdHandle`.
+
+Closed descriptors 0-2 keep a `/dev/null` substitution for the shell's *own* reads and writes, so
+those succeed where bash reports EBADF (issue #41 — fixing it needs an error path through every
+`io.fd_mut(n)` site). The closed marker is still recorded for them, so the child half is not
+deferred: `cmd 1>&-` leaves the child with no stdout and `exec 0<&-` leaves it with no stdin.
+
+`exec` makes its redirections permanent only when it succeeds. A rejected option drops them, as
+bash does — `exec -q 3>q` creates `q` but leaves fd 3 closed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ See CONTRIBUTING.md for detailed architecture (AST naming, operator precedence, 
   - `exec.rs` — Executor struct, main dispatch, alias expansion
   - `environment.rs` — variables, functions, scoping, arrays, aliases, declare attrs
   - `builtins.rs` — builtin commands (echo, cd, test, declare, printf, etc.)
-  - `special_builtins.rs` — eval, exec, source (need Executor access)
+  - `special_builtins.rs` — eval, exec, source (need Executor access). `exec` decides redirect-only mode *after* option parsing: if no command word survives, the redirections are adopted permanently — `exec --` and `exec -a name` reach that point with a non-empty argument list
   - `arithmetic.rs` — arithmetic expression evaluation
   - `bash_test.rs` — `[[ ]]` conditional evaluator
   - `printf.rs` — printf builtin formatter (custom, not Rust format!)
@@ -128,7 +128,7 @@ See CONTRIBUTING.md for detailed architecture (AST naming, operator precedence, 
   - `compound.rs` — compound command execution (if/while/for/case)
   - `pipeline.rs` — pipeline execution
   - `external.rs` + `command_ex.rs` — external process spawning; `terminal_inherit` enables direct terminal inheritance for interactive programs
-  - `redirect.rs` — redirect resolution; `ActiveRedirects` uses save/restore into `IoContext`
+  - `redirect.rs` — redirect resolution; `ActiveRedirects` uses save/restore into `IoContext`. A redirect list is last-one-wins, so opening a descriptor cancels an earlier close of it and vice versa. `N>&M-` / `N<&M-` duplicate M onto N and then close M
   - `subshell.rs` — subshell payload types
   - `numeric.rs` — shared shell-style numeric parsing
   - `pattern.rs` — shell glob pattern matching
@@ -137,6 +137,32 @@ See CONTRIBUTING.md for detailed architecture (AST naming, operator precedence, 
   - `error.rs` — ExecError types
 - `src/cli/` — CLI binary (yaml_writer, error_fmt, source_map, color)
 - `tests/parse.rs` + `tests/parse/` — parse tests (commands, pipelines, compound, redirects, errors, word_expansion, bash)
-- `tests/exec.rs` + `tests/exec/` — execution tests (basic, expansion, arrays, printf, bash)
+- `tests/exec.rs` + `tests/exec/` — execution tests (basic, expansion, arrays, printf, bash, descriptors)
 - `tests/cli.rs` + `tests/cli/` — CLI output tests
 - `crates/testkit/` — test infrastructure (sh_yaml parser, Docker helpers, callgrind parser, test tool binaries, test_tools fixture)
+
+### Closed descriptors
+
+`IoContext` tracks descriptors the script closed with `N>&-` separately from ones it simply never
+held. The distinction matters because thaum is embeddable:
+
+- **Absent** — the shell never touched this number, so a redirect may resolve it against the host
+  process's real fd table (`dup_process_fd`). That is ordinary POSIX inheritance and bash behaves
+  the same; a child writing to an inherited descriptor is not a bug.
+- **Closed** — the script closed it. It is not resolvable by a later `>&N`, and every child fd
+  table gets an `Fd::Close` entry for it. Without that entry `posix_spawn` inherits the number and
+  the child reaches whatever the *host* had there.
+
+thaum never calls `close(2)` on the host's descriptor — it is not thaum's to close. Recording the
+close and refusing to hand the number out is observably identical for the script and leaves the
+embedder intact.
+
+`Fd::Close` is implemented as `adddup2(/dev/null, fd)` followed by `addclose(fd)`. A bare
+`addclose` is not usable: if the number is not open, the child's `close(2)` fails and `posix_spawn`
+reports EBADF for the entire spawn (macOS). The dup2 makes the number open unconditionally, with no
+check-then-act against the process-global fd table. On Windows no action is needed — fds 3+ reach
+the child only through `build_lpreserved2`, where an absent entry already reads as closed.
+
+Closed descriptors 0-2 keep a `/dev/null` substitution for the shell's *own* writes, so those
+succeed where bash reports EBADF (issue #41 — fixing it needs an error path through every
+`io.fd_mut(n)` site). The child half is not deferred: `cmd 1>&-` leaves the child with no stdout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,23 @@ embedder intact.
 reports EBADF for the entire spawn (macOS). The dup2 makes the number open unconditionally, with no
 check-then-act against the process-global fd table.
 
-**Parent-side source descriptors are relocated above every target before any file action is
-added** (`relocate_above`, `F_DUPFD_CLOEXEC`). The child's actions dup2 *from* parent-side numbers
-and close *at* numbers in `cmd.fds`; if those sets overlap, an action destroys another's input and
+**Parent-side source descriptors are kept clear of every target before any file action is added**
+(`relocate_clear_of`, `F_DUPFD_CLOEXEC`). The child's actions dup2 *from* parent-side numbers and
+dup2/close *at* numbers in `cmd.fds`; if those sets overlap, an action destroys another's input and
 the spawn fails with EBADF. `cmd.fds` is a `HashMap`, so which entries collide depends on iteration
 order *and* on the host's fd table — the failure is nondeterministic and moves with the embedder.
 Actions are then emitted in a fixed order: every dup2, then every close.
+
+**A close never displaces a descriptor the runtime owns.** `CommandEx::reserve` claims the
+subshell's AST transport and the capture pipes; `CommandEx::close_fd_in_child` is the only way a
+script's `N>&-` reaches a child, and it refuses reserved numbers. Inserting `Fd::Close` directly
+would silently take the transport away — `exec 0<&-` did exactly that, and every subshell failed
+with "invalid JSON payload" while pointing the user at their data.
+
+A descriptor number the platform's spawn API refuses to name cannot be open in the child either, so
+that close is dropped rather than failing the spawn — bash prints `ok` for `exec 2000000>&-`. macOS
+rejects numbers from 10240 upward, a bound reachable through neither `sysconf(_SC_OPEN_MAX)`
+(1048576) nor `getdtablesize()` (245760), so the API is asked rather than guessed.
 
 On Windows, fds 3+ reach the child only through `build_lpreserved2`, where an absent entry already
 reads as closed. Descriptors 0-2 are **not** closed in the child on Windows: `close_in_child` gates

--- a/crates/test-tools/Cargo.toml
+++ b/crates/test-tools/Cargo.toml
@@ -55,3 +55,8 @@ test = false
 name = "test-isatty"
 path = "src/tools/isatty.rs"
 test = false
+
+[[bin]]
+name = "test-writefd"
+path = "src/tools/writefd.rs"
+test = false

--- a/crates/test-tools/src/lib.rs
+++ b/crates/test-tools/src/lib.rs
@@ -102,6 +102,7 @@ pub fn test_tools() -> Result<TestTools, String> {
         ("touch", "test-touch"),
         ("argv", "test-argv"),
         ("isatty", "test-isatty"),
+        ("writefd", "test-writefd"),
     ];
 
     for &(name, bin_name) in tools {

--- a/crates/test-tools/src/tools/writefd.rs
+++ b/crates/test-tools/src/tools/writefd.rs
@@ -1,0 +1,54 @@
+//! Minimal `writefd` — write a line to a raw file descriptor.
+//!
+//! A neutral observer for descriptor-inheritance tests: it reports whether a
+//! given descriptor number is usable in this process without going through any
+//! thaum code, so a test can distinguish "the parent closed it" from "the shell
+//! changed its mind about resolving it".
+//!
+//! Borrows the descriptor and releases it again without closing, so the
+//! caller's descriptor outlives the write.
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.len() != 2 {
+        eprintln!("writefd: usage: writefd <fd> <text>");
+        std::process::exit(2);
+    }
+    let fd: i32 = match args[0].parse() {
+        Ok(n) => n,
+        Err(e) => {
+            eprintln!("writefd: {}: {e}", args[0]);
+            std::process::exit(2);
+        }
+    };
+
+    match write_line(fd, &args[1]) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("writefd: {fd}: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn write_line(fd: i32, text: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::fd::{FromRawFd, IntoRawFd};
+
+    if fd < 0 {
+        return Err(std::io::Error::from(std::io::ErrorKind::InvalidInput));
+    }
+    // SAFETY: `fd` is treated as borrowed — `into_raw_fd` below releases it
+    // without closing, so this never invalidates the caller's descriptor.
+    let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+    let result = file.write_all(text.as_bytes()).and_then(|()| file.write_all(b"\n"));
+    let _ = file.into_raw_fd();
+    result
+}
+
+#[cfg(not(unix))]
+fn write_line(_fd: i32, _text: &str) -> std::io::Result<()> {
+    eprintln!("writefd: unsupported platform");
+    std::process::exit(2);
+}

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -224,7 +224,10 @@ impl Executor {
 
     /// Adopt redirects from `exec` redirect-only mode into persistent IoContext state.
     ///
-    /// All fds (0-2 and 3+) go into `io`. Explicitly closed fds are removed.
+    /// Opened fds (0-2 and 3+) go into `io`. Closed fds are *marked* closed, not
+    /// removed: 3+ lose their handle, while 0-2 keep a `/dev/null` handle so the
+    /// shell's own writers still find one. Either way the marker is what stops a
+    /// later `>&N` resolving the number and what denies it to children.
     fn adopt_redirects(&mut self, active: redirect::ActiveRedirects, io: &mut IoContext) {
         for fd in &active.closed_fds {
             if *fd <= 2 {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -297,9 +297,13 @@ impl Executor {
         };
 
         let mut cmd = CommandEx::new(vec![exe.into(), "exec-ast".into()]);
-        cmd.fds.insert(0, Fd::InputPipe); // parent writes JSON payload
-        cmd.fds.insert(1, Fd::Pipe); // parent reads stdout
-        cmd.fds.insert(2, Fd::Pipe); // parent reads stderr
+        // Reserved, not merely inserted: these carry the AST payload and the
+        // child's captured output. A script's `exec 0<&-` must not be able to
+        // take the transport away — that made every subshell fail with
+        // "invalid JSON payload" while pointing the user at their data.
+        cmd.reserve(0, Fd::InputPipe); // parent writes JSON payload
+        cmd.reserve(1, Fd::Pipe); // parent reads stdout
+        cmd.reserve(2, Fd::Pipe); // parent reads stderr
         cmd.cwd = Some(self.env.cwd().to_path_buf());
         // Inherit the full process environment so the child has system vars.
         cmd.env = std::env::vars_os().collect();
@@ -314,8 +318,8 @@ impl Executor {
         // Closed descriptors are closed in the subshell process too, so its own
         // `dup_process_fd` fallback fails naturally and nothing needs to travel
         // in the payload.
-        for &fd in io.closed_fds().iter().filter(|&&fd| command_ex::close_in_child(fd)) {
-            cmd.fds.insert(fd, Fd::Close);
+        for &fd in io.closed_fds() {
+            cmd.close_fd_in_child(fd);
         }
 
         let mut child = cmd.spawn().map_err(ExecError::Io)?;
@@ -637,7 +641,7 @@ impl Executor {
                             .into_iter()
                             .map(|(k, v): (String, String)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
                             .collect();
-                        child_cmd.fds.insert(1, command_ex::Fd::Pipe);
+                        child_cmd.reserve(1, command_ex::Fd::Pipe);
                         // Command substitution is a fifth spawn site and needs
                         // the same descriptor state as the others: the shell's
                         // fds 3+, and a real close for anything the script
@@ -652,8 +656,8 @@ impl Executor {
                                     .insert(fd, command_ex::Fd::File(file.try_clone().map_err(ExecError::Io)?));
                             }
                         }
-                        for &fd in io.closed_fds().iter().filter(|&&fd| command_ex::close_in_child(fd)) {
-                            child_cmd.fds.entry(fd).or_insert(command_ex::Fd::Close);
+                        for &fd in io.closed_fds() {
+                            child_cmd.close_fd_in_child(fd);
                         }
 
                         match child_cmd.spawn() {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -230,7 +230,7 @@ impl Executor {
             if *fd <= 2 {
                 io.set_fd(*fd, io_context::open_null_device());
             } else {
-                io.remove_fd(*fd);
+                io.close_fd(*fd);
             }
         }
         if let Some(f) = active.stdin {
@@ -303,6 +303,13 @@ impl Executor {
             if let Ok(file) = io.try_clone_fd(fd) {
                 cmd.fds.insert(fd, Fd::File(file));
             }
+        }
+
+        // Closed descriptors are closed in the subshell process too, so its own
+        // `dup_process_fd` fallback fails naturally and nothing needs to travel
+        // in the payload.
+        for &fd in io.closed_fds() {
+            cmd.fds.insert(fd, Fd::Close);
         }
 
         let mut child = cmd.spawn().map_err(ExecError::Io)?;
@@ -830,14 +837,11 @@ impl Executor {
                 return result;
             }
             "exec" => {
+                // Redirect-only mode is decided inside `builtin_exec`, after
+                // option parsing — `exec --` and `exec -a name` reach it with a
+                // non-empty argument list but no command word.
                 let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
-                if cmd_args.is_empty() {
-                    // Redirect-only mode: adopt redirects permanently into IoContext.
-                    self.adopt_redirects(active, io);
-                    self.restore_prefix_assignments(saved_env);
-                    return Ok(0);
-                }
-                let result = self.builtin_exec(cmd_args, &mut active, io);
+                let result = self.builtin_exec(cmd_args, active, io);
                 self.restore_prefix_assignments(saved_env);
                 return result;
             }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -314,7 +314,7 @@ impl Executor {
         // Closed descriptors are closed in the subshell process too, so its own
         // `dup_process_fd` fallback fails naturally and nothing needs to travel
         // in the payload.
-        for &fd in io.closed_fds() {
+        for &fd in io.closed_fds().iter().filter(|&&fd| command_ex::close_in_child(fd)) {
             cmd.fds.insert(fd, Fd::Close);
         }
 
@@ -652,7 +652,7 @@ impl Executor {
                                     .insert(fd, command_ex::Fd::File(file.try_clone().map_err(ExecError::Io)?));
                             }
                         }
-                        for &fd in io.closed_fds() {
+                        for &fd in io.closed_fds().iter().filter(|&&fd| command_ex::close_in_child(fd)) {
                             child_cmd.fds.entry(fd).or_insert(command_ex::Fd::Close);
                         }
 

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -228,7 +228,13 @@ impl Executor {
     fn adopt_redirects(&mut self, active: redirect::ActiveRedirects, io: &mut IoContext) {
         for fd in &active.closed_fds {
             if *fd <= 2 {
+                // Substitute /dev/null so the shell's own writers always find a
+                // handle, but still record the close: children must be denied
+                // the descriptor, or `exec 0<&-; cat` reads the *host's* stdin.
+                // (The shell's own reads/writes still hit /dev/null rather than
+                // reporting EBADF — that half is issue #41.)
                 io.set_fd(*fd, io_context::open_null_device());
+                io.set_closed_marker(*fd, true);
             } else {
                 io.close_fd(*fd);
             }
@@ -451,16 +457,16 @@ impl Executor {
     }
 
     /// Expand a word, resolving command substitutions first.
-    fn expand_word(&mut self, word: &crate::ast::Word) -> Result<String, ExecError> {
-        let resolved = self.resolve_cmd_subs_in_word(word)?;
+    fn expand_word(&mut self, word: &crate::ast::Word, io: &IoContext) -> Result<String, ExecError> {
+        let resolved = self.resolve_cmd_subs_in_word(word, io)?;
         expand::expand_word(&resolved, &mut self.env)
     }
 
     /// Expand an argument, resolving command substitutions first.
-    fn expand_argument(&mut self, arg: &crate::ast::Argument) -> Result<Vec<String>, ExecError> {
+    fn expand_argument(&mut self, arg: &crate::ast::Argument, io: &IoContext) -> Result<Vec<String>, ExecError> {
         match arg {
             crate::ast::Argument::Word(word) => {
-                let resolved = self.resolve_cmd_subs_in_word(word)?;
+                let resolved = self.resolve_cmd_subs_in_word(word, io)?;
                 expand::expand_word_to_fields(&resolved, &mut self.env)
             }
             crate::ast::Argument::Atom(atom) => match atom {
@@ -472,15 +478,19 @@ impl Executor {
     }
 
     /// Expand a word into fields, resolving command substitutions first.
-    fn expand_word_to_fields(&mut self, word: &crate::ast::Word) -> Result<Vec<String>, ExecError> {
-        let resolved = self.resolve_cmd_subs_in_word(word)?;
+    fn expand_word_to_fields(&mut self, word: &crate::ast::Word, io: &IoContext) -> Result<Vec<String>, ExecError> {
+        let resolved = self.resolve_cmd_subs_in_word(word, io)?;
         expand::expand_word_to_fields(&resolved, &mut self.env)
     }
 
     /// Pre-process a Word, executing command substitutions and replacing
     /// them with Literal fragments containing the captured output.
-    fn resolve_cmd_subs_in_word(&mut self, word: &crate::ast::Word) -> Result<crate::ast::Word, ExecError> {
-        let new_parts = self.resolve_cmd_subs_in_fragments(&word.parts)?;
+    fn resolve_cmd_subs_in_word(
+        &mut self,
+        word: &crate::ast::Word,
+        io: &IoContext,
+    ) -> Result<crate::ast::Word, ExecError> {
+        let new_parts = self.resolve_cmd_subs_in_fragments(&word.parts, io)?;
         Ok(crate::ast::Word {
             parts: new_parts,
             span: word.span,
@@ -491,13 +501,14 @@ impl Executor {
     fn resolve_cmd_subs_in_fragments(
         &mut self,
         fragments: &[crate::ast::Fragment],
+        io: &IoContext,
     ) -> Result<Vec<crate::ast::Fragment>, ExecError> {
         use crate::ast::Fragment;
         let mut result = Vec::with_capacity(fragments.len());
         for fragment in fragments {
             match fragment {
                 Fragment::CommandSubstitution(stmts) => {
-                    let output = self.execute_command_substitution(stmts)?;
+                    let output = self.execute_command_substitution(stmts, io)?;
                     // Strip trailing newlines (POSIX behavior)
                     let trimmed = output.trim_end_matches('\n').to_string();
                     result.push(Fragment::Literal(trimmed));
@@ -507,11 +518,11 @@ impl Executor {
                     result.push(Fragment::Literal(value.to_string()));
                 }
                 Fragment::DoubleQuoted(parts) => {
-                    let resolved = self.resolve_cmd_subs_in_fragments(parts)?;
+                    let resolved = self.resolve_cmd_subs_in_fragments(parts, io)?;
                     result.push(Fragment::DoubleQuoted(resolved));
                 }
                 Fragment::BashLocaleQuoted { raw, parts } => {
-                    let resolved = self.resolve_cmd_subs_in_fragments(parts)?;
+                    let resolved = self.resolve_cmd_subs_in_fragments(parts, io)?;
                     result.push(Fragment::BashLocaleQuoted {
                         raw: raw.clone(),
                         parts: resolved,
@@ -548,7 +559,7 @@ impl Executor {
                         _ => true,
                     };
                     let resolved_arg = if needs_resolution {
-                        Box::new(self.resolve_cmd_subs_in_word(arg)?)
+                        Box::new(self.resolve_cmd_subs_in_word(arg, io)?)
                     } else {
                         arg.clone()
                     };
@@ -572,7 +583,7 @@ impl Executor {
     /// the output buffer. For external commands, uses piped stdout.
     /// Creates its own internal IoContext with a capture buffer for stdout
     /// and io::sink() for stderr (discarding stderr from command substitutions).
-    fn execute_command_substitution(&mut self, stmts: &[Statement]) -> Result<String, ExecError> {
+    fn execute_command_substitution(&mut self, stmts: &[Statement], io: &IoContext) -> Result<String, ExecError> {
         let mut captured = Vec::new();
 
         for stmt in stmts {
@@ -586,7 +597,7 @@ impl Executor {
 
                     if args.is_empty() {
                         for assignment in &cmd.assignments {
-                            self.execute_assignment(assignment)?;
+                            self.execute_assignment(assignment, io)?;
                         }
                         continue;
                     }
@@ -627,6 +638,23 @@ impl Executor {
                             .map(|(k, v): (String, String)| (std::ffi::OsString::from(k), std::ffi::OsString::from(v)))
                             .collect();
                         child_cmd.fds.insert(1, command_ex::Fd::Pipe);
+                        // Command substitution is a fifth spawn site and needs
+                        // the same descriptor state as the others: the shell's
+                        // fds 3+, and a real close for anything the script
+                        // closed. Without this `x=$(sh -c "echo >&3")` bypassed
+                        // `exec 3>file` entirely and wrote to the *host's*
+                        // descriptor 3 — the shape that corrupted the corpus
+                        // harness's database.
+                        for (&fd, file) in io.fds() {
+                            if fd >= 3 {
+                                child_cmd
+                                    .fds
+                                    .insert(fd, command_ex::Fd::File(file.try_clone().map_err(ExecError::Io)?));
+                            }
+                        }
+                        for &fd in io.closed_fds() {
+                            child_cmd.fds.entry(fd).or_insert(command_ex::Fd::Close);
+                        }
 
                         match child_cmd.spawn() {
                             Ok(mut child) => {
@@ -714,7 +742,7 @@ impl Executor {
             match arg.try_to_static_string() {
                 Some(s) => remaining_source.push_str(&s),
                 None => {
-                    let fields = self.expand_argument(arg)?;
+                    let fields = self.expand_argument(arg, io)?;
                     remaining_source.push_str(&fields.join(" "));
                 }
             }
@@ -783,7 +811,7 @@ impl Executor {
         // Expand arguments
         let mut expanded_args: Vec<String> = Vec::new();
         for arg in &cmd.arguments {
-            let fields = self.expand_argument(arg)?;
+            let fields = self.expand_argument(arg, io)?;
             expanded_args.extend(fields);
         }
 
@@ -804,7 +832,7 @@ impl Executor {
         // If no command name, just process assignments
         if expanded_args.is_empty() {
             for assignment in &cmd.assignments {
-                self.execute_assignment(assignment)?;
+                self.execute_assignment(assignment, io)?;
             }
             // POSIX: bare assignments return the exit status of the last
             // command substitution executed during value expansion.
@@ -821,7 +849,7 @@ impl Executor {
         // Check for special builtins (need Executor access, not just Environment).
         match cmd_name.as_str() {
             "eval" => {
-                let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
+                let saved_env = self.apply_prefix_assignments(&cmd.assignments, io)?;
                 let saved_fds = active.apply(io);
                 let result = self.builtin_eval(cmd_args, io);
                 saved_fds.restore(io);
@@ -829,7 +857,7 @@ impl Executor {
                 return result;
             }
             "source" | "." => {
-                let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
+                let saved_env = self.apply_prefix_assignments(&cmd.assignments, io)?;
                 let saved_fds = active.apply(io);
                 let result = self.builtin_source(cmd_args, io);
                 saved_fds.restore(io);
@@ -840,7 +868,7 @@ impl Executor {
                 // Redirect-only mode is decided inside `builtin_exec`, after
                 // option parsing — `exec --` and `exec -a name` reach it with a
                 // non-empty argument list but no command word.
-                let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
+                let saved_env = self.apply_prefix_assignments(&cmd.assignments, io)?;
                 let result = self.builtin_exec(cmd_args, active, io);
                 self.restore_prefix_assignments(saved_env);
                 return result;
@@ -850,7 +878,7 @@ impl Executor {
 
         // Check for functions first
         if let Some(func) = self.env.get_function(cmd_name).cloned() {
-            let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
+            let saved_env = self.apply_prefix_assignments(&cmd.assignments, io)?;
             let call_info = environment::CallInfo {
                 function_name: cmd_name.to_string(),
                 source_file: func.def_source.clone(),
@@ -894,7 +922,7 @@ impl Executor {
         };
 
         if is_active_builtin {
-            let saved_env = self.apply_prefix_assignments(&cmd.assignments)?;
+            let saved_env = self.apply_prefix_assignments(&cmd.assignments, io)?;
             let saved_fds = active.apply(io);
 
             let mut stdout_buf: Vec<u8> = Vec::new();
@@ -934,7 +962,7 @@ impl Executor {
             // has created the associative array before we set subscripted elements.
             for assignment in &cmd.assignments {
                 if matches!(assignment.value, crate::ast::AssignmentValue::BashArray(_)) {
-                    self.execute_assignment(assignment)?;
+                    self.execute_assignment(assignment, io)?;
                 }
             }
 
@@ -962,10 +990,14 @@ impl Executor {
     }
 
     /// Execute a full assignment (scalar, indexed, or array), with append support.
-    pub(crate) fn execute_assignment(&mut self, assignment: &crate::ast::Assignment) -> Result<(), ExecError> {
+    pub(crate) fn execute_assignment(
+        &mut self,
+        assignment: &crate::ast::Assignment,
+        io: &IoContext,
+    ) -> Result<(), ExecError> {
         if let Some(ref subscript) = assignment.index {
             // Indexed or associative assignment: name[subscript]=value or name[subscript]+=value
-            let value = self.expand_word(assignment.value.as_scalar())?;
+            let value = self.expand_word(assignment.value.as_scalar(), io)?;
             if self.env.is_assoc_array(&assignment.name) {
                 if assignment.append {
                     let old = self
@@ -995,7 +1027,7 @@ impl Executor {
         } else {
             match &assignment.value {
                 crate::ast::AssignmentValue::Scalar(word) => {
-                    let value = self.expand_word(word)?;
+                    let value = self.expand_word(word, io)?;
                     if assignment.append {
                         if self.env.has_integer_attr(&assignment.name) {
                             let old_str = self.env.get_var(&assignment.name).unwrap_or("0").to_string();
@@ -1018,9 +1050,9 @@ impl Executor {
                 }
                 crate::ast::AssignmentValue::BashArray(elems) => {
                     if assignment.append {
-                        self.execute_array_append(&assignment.name, elems)?;
+                        self.execute_array_append(&assignment.name, elems, io)?;
                     } else {
-                        self.execute_array_assign(&assignment.name, elems)?;
+                        self.execute_array_assign(&assignment.name, elems, io)?;
                     }
                 }
             }
@@ -1037,19 +1069,24 @@ impl Executor {
     }
 
     /// Replace an array variable with new elements (non-append).
-    fn execute_array_assign(&mut self, name: &str, elems: &[crate::ast::ArrayElement]) -> Result<(), ExecError> {
+    fn execute_array_assign(
+        &mut self,
+        name: &str,
+        elems: &[crate::ast::ArrayElement],
+        io: &IoContext,
+    ) -> Result<(), ExecError> {
         let mut plain_elements = Vec::new();
         for elem in elems {
             match elem {
                 crate::ast::ArrayElement::Plain(word) => {
-                    plain_elements.push(self.expand_word(word)?);
+                    plain_elements.push(self.expand_word(word, io)?);
                 }
                 crate::ast::ArrayElement::Subscripted { index, value } => {
                     // Flush any accumulated plain elements first
                     if !plain_elements.is_empty() {
                         self.env.set_array(name, std::mem::take(&mut plain_elements))?;
                     }
-                    let val = self.expand_word(value)?;
+                    let val = self.expand_word(value, io)?;
                     if self.env.is_assoc_array(name) {
                         self.env.set_assoc_element(name, index, &val)?;
                     } else {
@@ -1066,17 +1103,22 @@ impl Executor {
     }
 
     /// Append elements to an existing array (or create one).
-    fn execute_array_append(&mut self, name: &str, elems: &[crate::ast::ArrayElement]) -> Result<(), ExecError> {
+    fn execute_array_append(
+        &mut self,
+        name: &str,
+        elems: &[crate::ast::ArrayElement],
+        io: &IoContext,
+    ) -> Result<(), ExecError> {
         let mut next_idx = self.env.get_array_next_index(name);
         for elem in elems {
             match elem {
                 crate::ast::ArrayElement::Plain(word) => {
-                    let val = self.expand_word(word)?;
+                    let val = self.expand_word(word, io)?;
                     self.env.set_array_element(name, next_idx, &val)?;
                     next_idx += 1;
                 }
                 crate::ast::ArrayElement::Subscripted { index, value } => {
-                    let val = self.expand_word(value)?;
+                    let val = self.expand_word(value, io)?;
                     if self.env.is_assoc_array(name) {
                         self.env.set_assoc_element(name, index, &val)?;
                     } else {
@@ -1108,8 +1150,9 @@ impl Executor {
     pub(crate) fn expand_scalar_assignment(
         &mut self,
         assignment: &crate::ast::Assignment,
+        io: &IoContext,
     ) -> Result<String, ExecError> {
-        self.expand_word(assignment.value.as_scalar())
+        self.expand_word(assignment.value.as_scalar(), io)
     }
 
     /// Apply prefix assignments temporarily, returning saved values.
@@ -1120,6 +1163,7 @@ impl Executor {
     fn apply_prefix_assignments(
         &mut self,
         assignments: &[crate::ast::Assignment],
+        io: &IoContext,
     ) -> Result<Vec<(String, Option<String>, bool)>, ExecError> {
         let mut saved = Vec::new();
         for assignment in assignments {
@@ -1129,7 +1173,7 @@ impl Executor {
             }
             let old_val = self.env.get_var(&assignment.name).map(|s| s.to_string());
             let old_exported = self.env.is_exported(&assignment.name);
-            let expanded = self.expand_scalar_assignment(assignment)?;
+            let expanded = self.expand_scalar_assignment(assignment, io)?;
             let value = if assignment.append {
                 let old = old_val.as_deref().unwrap_or("");
                 format!("{old}{expanded}")

--- a/src/exec/bash_test.rs
+++ b/src/exec/bash_test.rs
@@ -13,37 +13,37 @@ use crate::exec::Executor;
 
 /// Evaluate a `[[ ]]` conditional expression. Returns true/false.
 ///
-/// The `_io` parameter is currently unused but reserved for future use
+/// The `io` parameter is currently unused but reserved for future use
 /// (e.g., command substitution inside test expressions that needs IO).
-pub fn evaluate(expr: &BashTestExpr, executor: &mut Executor, _io: &mut IoContext) -> Result<bool, ExecError> {
+pub fn evaluate(expr: &BashTestExpr, executor: &mut Executor, io: &mut IoContext) -> Result<bool, ExecError> {
     match expr {
         BashTestExpr::And { left, right } => {
-            if !evaluate(left, executor, _io)? {
+            if !evaluate(left, executor, io)? {
                 Ok(false)
             } else {
-                evaluate(right, executor, _io)
+                evaluate(right, executor, io)
             }
         }
         BashTestExpr::Or { left, right } => {
-            if evaluate(left, executor, _io)? {
+            if evaluate(left, executor, io)? {
                 Ok(true)
             } else {
-                evaluate(right, executor, _io)
+                evaluate(right, executor, io)
             }
         }
-        BashTestExpr::Not(inner) => Ok(!evaluate(inner, executor, _io)?),
-        BashTestExpr::Group(inner) => evaluate(inner, executor, _io),
+        BashTestExpr::Not(inner) => Ok(!evaluate(inner, executor, io)?),
+        BashTestExpr::Group(inner) => evaluate(inner, executor, io),
         BashTestExpr::Word(w) => {
-            let s = executor.expand_word(w)?;
+            let s = executor.expand_word(w, io)?;
             Ok(!s.is_empty())
         }
         BashTestExpr::Unary { op, arg } => {
-            let s = executor.expand_word(arg)?;
+            let s = executor.expand_word(arg, io)?;
             Ok(evaluate_unary(*op, &s, executor.env()))
         }
         BashTestExpr::Binary { left, op, right } => {
-            let l = executor.expand_word(left)?;
-            let r = executor.expand_word(right)?;
+            let l = executor.expand_word(left, io)?;
+            let r = executor.expand_word(right, io)?;
             evaluate_binary(&l, *op, &r, executor.env_mut())
         }
     }

--- a/src/exec/command_ex.rs
+++ b/src/exec/command_ex.rs
@@ -33,18 +33,6 @@ pub(crate) enum Fd {
     Close,
 }
 
-/// Whether a descriptor the script closed should also be closed in the child.
-///
-/// Descriptors 3+ on every platform. Standard descriptors only on Unix: routing
-/// 0-2 to [`Fd::Close`] on Windows would take an untested path through
-/// `STARTF_USESTDHANDLES`, and nobody working on this can run Windows. Gating
-/// leaves that platform behaving exactly as it did before — see issue #46,
-/// which also records that Windows therefore keeps the pre-existing
-/// `cmd 1>&-` divergence rather than gaining a new one.
-pub(crate) fn close_in_child(fd: i32) -> bool {
-    fd > 2 || cfg!(unix)
-}
-
 // CommandEx ===========================================================================================================
 
 /// Description of a child process to spawn. All fields are public; callers
@@ -63,6 +51,10 @@ pub(crate) struct CommandEx {
     /// File descriptor table. Keys are fd numbers (0 = stdin, 1 = stdout, …).
     /// Fds not present here inherit from the parent process.
     pub fds: HashMap<i32, Fd>,
+    /// Descriptors the runtime owns for its own plumbing — a subshell's AST
+    /// transport, a capture pipe. [`close_fd_in_child`](CommandEx::close_fd_in_child)
+    /// refuses to displace these. Set via [`reserve`](CommandEx::reserve).
+    reserved: std::collections::HashSet<i32>,
 }
 
 impl CommandEx {
@@ -77,7 +69,40 @@ impl CommandEx {
             env: std::env::vars_os().collect(),
             cwd: None,
             fds: HashMap::new(),
+            reserved: std::collections::HashSet::new(),
         }
+    }
+
+    /// Claim `fd` for the runtime's own plumbing.
+    ///
+    /// Reserved descriptors are exempt from [`close_fd_in_child`](CommandEx::close_fd_in_child):
+    /// a script closing a descriptor must not be able to take away the channel
+    /// the runtime is using to talk to its own child. `exec 0<&-` did exactly
+    /// that to the subshell transport, and every subshell stopped running.
+    pub fn reserve(&mut self, fd: i32, spec: Fd) {
+        self.fds.insert(fd, spec);
+        self.reserved.insert(fd);
+    }
+
+    /// Ask for `fd` to be closed in the child.
+    ///
+    /// The single place that decides whether a script's `N>&-` reaches a child.
+    /// Three reasons it may not:
+    ///
+    /// * the runtime reserved the descriptor (see [`reserve`](CommandEx::reserve));
+    /// * it is a standard descriptor on Windows, where the close path is
+    ///   unexercised, so that platform keeps its previous behaviour (issue #46).
+    ///
+    /// A number too large for the platform's spawn API to name is handled at
+    /// emission time, in `spawn_impl`, where the API reports it.
+    pub fn close_fd_in_child(&mut self, fd: i32) {
+        if self.reserved.contains(&fd) {
+            return;
+        }
+        if fd <= 2 && !cfg!(unix) {
+            return;
+        }
+        self.fds.insert(fd, Fd::Close);
     }
 
     /// Join `self.argv` into a single command-line string using platform
@@ -712,41 +737,56 @@ fn get_terminal_size() -> libc::winsize {
     }
 }
 
-/// Move a parent-side source descriptor to a number at or above `floor`,
-/// closing the original.
+/// Move a parent-side source descriptor clear of every descriptor the child's
+/// fd table targets, closing the original.
 ///
-/// The child's file actions dup2 *from* these numbers and close *at* the
-/// numbers in `cmd.fds`. Those two sets must not overlap: if a source happens
-/// to sit on a number the child also closes — or that a later dup2 overwrites —
-/// the action list destroys its own input and `posix_spawn` fails the whole
-/// spawn with EBADF. Which numbers collide depends on the host process's fd
-/// table and on `HashMap` iteration order, so the failure is nondeterministic
-/// and varies with what the embedder happens to have open.
+/// The child's file actions dup2 *from* these numbers and dup2/close *at* the
+/// numbers in `cmd.fds`. The two sets must be disjoint: if a source sits on a
+/// number the child also closes — or that another dup2 overwrites — the action
+/// list destroys its own input and `posix_spawn` fails the whole spawn with
+/// EBADF. Which numbers collide depends on the host process's fd table and on
+/// `HashMap` iteration order, so the failure is nondeterministic and moves with
+/// whatever the embedder happens to have open.
 ///
-/// `F_DUPFD_CLOEXEC` gives the lowest free number ≥ `floor`, and the duplicate
-/// is close-on-exec, so it serves the file actions (which run before exec) and
-/// then disappears rather than leaking into the child.
+/// Each colliding duplicate is parked so the next `F_DUPFD_CLOEXEC` cannot
+/// return the same number; the loop therefore consumes one distinct target per
+/// iteration and ends within `targets.len()` steps. `F_DUPFD_CLOEXEC` keeps the
+/// duplicate close-on-exec, so it serves the file actions — which run before
+/// exec — and then disappears rather than leaking into the child.
 #[cfg(unix)]
-fn relocate_above(
+fn relocate_clear_of(
     raw: std::os::fd::RawFd,
-    floor: std::os::fd::RawFd,
+    targets: &std::collections::HashSet<i32>,
     raw_fds_to_close: &[std::os::fd::RawFd],
 ) -> io::Result<std::os::fd::RawFd> {
-    if raw >= floor {
+    if !targets.contains(&raw) {
         return Ok(raw);
     }
-    // SAFETY: `raw` is an owned descriptor produced by `into_raw_fd`.
-    let moved = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, floor) };
-    if moved < 0 {
-        let err = io::Error::last_os_error();
-        // SAFETY: `raw` is still open and owned here.
-        unsafe { libc::close(raw) };
-        close_raw_fds(raw_fds_to_close);
-        return Err(err);
+    let mut parked: Vec<std::os::fd::RawFd> = Vec::new();
+    let mut cur = raw;
+    let outcome = loop {
+        // SAFETY: `cur` is an owned, open descriptor.
+        let next = unsafe { libc::fcntl(cur, libc::F_DUPFD_CLOEXEC, 3) };
+        if next < 0 {
+            break Err(io::Error::last_os_error());
+        }
+        parked.push(cur);
+        if !targets.contains(&next) {
+            break Ok(next);
+        }
+        cur = next;
+    };
+    for fd in parked {
+        // SAFETY: each parked fd is owned here and superseded by its duplicate.
+        unsafe { libc::close(fd) };
     }
-    // SAFETY: the duplicate now holds the description; release the original.
-    unsafe { libc::close(raw) };
-    Ok(moved)
+    match outcome {
+        Ok(fd) => Ok(fd),
+        Err(e) => {
+            close_raw_fds(raw_fds_to_close);
+            Err(e)
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -763,10 +803,9 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     // Lazily-opened /dev/null, shared by all `Fd::Close` entries.
     let mut devnull_fd: Option<std::os::fd::RawFd> = None;
 
-    // Every descriptor number the child's fd table will touch. Parent-side
-    // source fds are relocated above this so that no `dup2` target and no
-    // `close` can ever land on a source — see `relocate_above`.
-    let relocation_floor = cmd.fds.keys().copied().max().unwrap_or(-1) + 1;
+    // Every descriptor number the child's fd table targets. Parent-side source
+    // fds are kept clear of this set — see `relocate_clear_of`.
+    let targets: std::collections::HashSet<i32> = cmd.fds.keys().copied().collect();
 
     // Collected actions, applied after the loop in a fixed order: every dup2
     // first, then every close. `cmd.fds` is a HashMap, so the iteration order
@@ -774,12 +813,15 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     // order-dependent and therefore nondeterministic.
     let mut dup2_actions: Vec<(std::os::fd::RawFd, i32)> = Vec::new();
     let mut close_actions: Vec<i32> = Vec::new();
+    // Targets that exist only to be closed. If the platform's spawn API cannot
+    // name the number, the close is vacuous rather than fatal — see below.
+    let mut close_only: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
     for (&fd_num, fd_spec) in &cmd.fds {
         match fd_spec {
             Fd::Pipe => {
                 let (read_end, write_end) = nix::unistd::pipe().map_err(io::Error::other)?;
-                let write_raw = relocate_above(write_end.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
+                let write_raw = relocate_clear_of(write_end.into_raw_fd(), &targets, &raw_fds_to_close)?;
                 raw_fds_to_close.push(write_raw);
                 dup2_actions.push((write_raw, fd_num));
                 let parent_file = File::from(read_end);
@@ -788,7 +830,7 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
             }
             Fd::InputPipe => {
                 let (read_end, write_end) = nix::unistd::pipe().map_err(io::Error::other)?;
-                let read_raw = relocate_above(read_end.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
+                let read_raw = relocate_clear_of(read_end.into_raw_fd(), &targets, &raw_fds_to_close)?;
                 raw_fds_to_close.push(read_raw);
                 dup2_actions.push((read_raw, fd_num));
                 let parent_file = File::from(write_end);
@@ -807,9 +849,9 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                     attrs.output_flags.remove(OutputFlags::ONLCR);
                     termios::tcsetattr(&pty.slave, SetArg::TCSANOW, &attrs).map_err(io::Error::other)?;
                 }
-                // Relocated above every target, so the "close the slave in the
+                // Kept clear of every target, so the "close the slave in the
                 // child" action below can never destroy a target fd.
-                let slave_raw = relocate_above(pty.slave.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
+                let slave_raw = relocate_clear_of(pty.slave.into_raw_fd(), &targets, &raw_fds_to_close)?;
                 raw_fds_to_close.push(slave_raw);
                 dup2_actions.push((slave_raw, fd_num));
                 // Close the original slave fd in the child after dup2. Without
@@ -821,7 +863,7 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                 pipes.insert(fd_num, master_file);
             }
             Fd::File(file) => {
-                let raw_fd = relocate_above(file.try_clone()?.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
+                let raw_fd = relocate_clear_of(file.try_clone()?.into_raw_fd(), &targets, &raw_fds_to_close)?;
                 raw_fds_to_close.push(raw_fd);
                 dup2_actions.push((raw_fd, fd_num));
             }
@@ -842,7 +884,7 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                             .inspect_err(|_| {
                                 close_raw_fds(&raw_fds_to_close);
                             })?;
-                        let raw = relocate_above(file.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
+                        let raw = relocate_clear_of(file.into_raw_fd(), &targets, &raw_fds_to_close)?;
                         raw_fds_to_close.push(raw);
                         devnull_fd = Some(raw);
                         raw
@@ -850,24 +892,49 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                 };
                 dup2_actions.push((devnull_raw, fd_num));
                 close_actions.push(fd_num);
+                close_only.insert(fd_num);
             }
         }
     }
 
-    // Deterministic order: all dup2s, then all closes. Safe because every
-    // source is above `relocation_floor` and every dup2 target is below it, so
-    // no close in the second pass can invalidate a source used in the first.
+    // Deterministic order: all dup2s, then all closes. Safe because no source
+    // is a member of `targets`, so no close in the second pass can invalidate a
+    // source used in the first.
     dup2_actions.sort_unstable();
     close_actions.sort_unstable();
+
+    // A descriptor number the spawn API refuses to name cannot be open in the
+    // child either, so closing it is a no-op — which is what bash does:
+    // `exec 2000000>&-; echo ok` prints "ok". macOS rejects such numbers from
+    // `posix_spawn_file_actions_adddup2` with EBADF from 10240 upward, and that
+    // bound is not reachable through `sysconf(_SC_OPEN_MAX)` (1048576) or
+    // `getdtablesize()` (245760) — so rather than guess it, let the API say so
+    // and drop the vacuous action. Anything that is not merely a close still
+    // propagates: a real redirect to an unusable descriptor is an error.
+    let vacuous = |fd: i32, e: &io::Error| close_only.contains(&fd) && e.raw_os_error() == Some(libc::EBADF);
+
+    let mut dropped: std::collections::HashSet<i32> = std::collections::HashSet::new();
     for (src, dst) in dup2_actions {
-        file_actions.add_dup2(src, dst).inspect_err(|_| {
+        if let Err(e) = file_actions.add_dup2(src, dst) {
+            if vacuous(dst, &e) {
+                dropped.insert(dst);
+                continue;
+            }
             close_raw_fds(&raw_fds_to_close);
-        })?;
+            return Err(e);
+        }
     }
     for fd in close_actions {
-        file_actions.add_close(fd).inspect_err(|_| {
+        if dropped.contains(&fd) {
+            continue;
+        }
+        if let Err(e) = file_actions.add_close(fd) {
+            if vacuous(fd, &e) {
+                continue;
+            }
             close_raw_fds(&raw_fds_to_close);
-        })?;
+            return Err(e);
+        }
     }
 
     // Set child CWD. Prefer addchdir_np (no process-global side effects);

--- a/src/exec/command_ex.rs
+++ b/src/exec/command_ex.rs
@@ -27,6 +27,10 @@ pub(crate) enum Fd {
     Pty,
     /// Redirect to/from this file.
     File(File),
+    /// Not open in the child. Used for descriptors the script closed with
+    /// `N>&-`: omitting them would silently hand the child whatever the *host*
+    /// process has at that number.
+    Close,
 }
 
 // CommandEx ===========================================================================================================
@@ -330,6 +334,11 @@ impl CommandEx {
                         // SAFETY: raw is valid and no longer needed (dup2 made a copy).
                         unsafe { nix::libc::close(raw) };
                     }
+                }
+                Fd::Close => {
+                    // SAFETY: close() is safe for any fd number; EBADF (the fd
+                    // was not open) is the expected no-op case and is ignored.
+                    unsafe { nix::libc::close(fd_num) };
                 }
                 Fd::Pipe | Fd::InputPipe | Fd::Pty => {} // Not meaningful for exec replacement.
             }
@@ -702,6 +711,8 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     let mut pipes: HashMap<i32, File> = HashMap::new();
     // Raw FDs that must be closed in the parent after spawn (or on error).
     let mut raw_fds_to_close: Vec<std::os::fd::RawFd> = Vec::new();
+    // Lazily-opened /dev/null, shared by all `Fd::Close` entries.
+    let mut devnull_fd: Option<std::os::fd::RawFd> = None;
 
     for (&fd_num, fd_spec) in &cmd.fds {
         match fd_spec {
@@ -762,6 +773,36 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                 let raw_fd = file.try_clone()?.into_raw_fd();
                 raw_fds_to_close.push(raw_fd);
                 file_actions.add_dup2(raw_fd, fd_num).inspect_err(|_| {
+                    close_raw_fds(&raw_fds_to_close);
+                })?;
+            }
+            Fd::Close => {
+                // A bare `addclose` is not usable here: if `fd_num` is not open
+                // in this process, the child's close(2) fails and posix_spawn
+                // reports EBADF for the whole spawn (verified on macOS 15).
+                // Checking first would be a check-then-act on a process-global
+                // table, so instead dup /dev/null onto the number — which makes
+                // it open unconditionally — and close that.
+                let devnull_raw = match devnull_fd {
+                    Some(raw) => raw,
+                    None => {
+                        let file = File::options()
+                            .read(true)
+                            .write(true)
+                            .open("/dev/null")
+                            .inspect_err(|_| {
+                                close_raw_fds(&raw_fds_to_close);
+                            })?;
+                        let raw = file.into_raw_fd();
+                        raw_fds_to_close.push(raw);
+                        devnull_fd = Some(raw);
+                        raw
+                    }
+                };
+                file_actions.add_dup2(devnull_raw, fd_num).inspect_err(|_| {
+                    close_raw_fds(&raw_fds_to_close);
+                })?;
+                file_actions.add_close(fd_num).inspect_err(|_| {
                     close_raw_fds(&raw_fds_to_close);
                 })?;
             }

--- a/src/exec/command_ex.rs
+++ b/src/exec/command_ex.rs
@@ -700,6 +700,43 @@ fn get_terminal_size() -> libc::winsize {
     }
 }
 
+/// Move a parent-side source descriptor to a number at or above `floor`,
+/// closing the original.
+///
+/// The child's file actions dup2 *from* these numbers and close *at* the
+/// numbers in `cmd.fds`. Those two sets must not overlap: if a source happens
+/// to sit on a number the child also closes — or that a later dup2 overwrites —
+/// the action list destroys its own input and `posix_spawn` fails the whole
+/// spawn with EBADF. Which numbers collide depends on the host process's fd
+/// table and on `HashMap` iteration order, so the failure is nondeterministic
+/// and varies with what the embedder happens to have open.
+///
+/// `F_DUPFD_CLOEXEC` gives the lowest free number ≥ `floor`, and the duplicate
+/// is close-on-exec, so it serves the file actions (which run before exec) and
+/// then disappears rather than leaking into the child.
+#[cfg(unix)]
+fn relocate_above(
+    raw: std::os::fd::RawFd,
+    floor: std::os::fd::RawFd,
+    raw_fds_to_close: &[std::os::fd::RawFd],
+) -> io::Result<std::os::fd::RawFd> {
+    if raw >= floor {
+        return Ok(raw);
+    }
+    // SAFETY: `raw` is an owned descriptor produced by `into_raw_fd`.
+    let moved = unsafe { libc::fcntl(raw, libc::F_DUPFD_CLOEXEC, floor) };
+    if moved < 0 {
+        let err = io::Error::last_os_error();
+        // SAFETY: `raw` is still open and owned here.
+        unsafe { libc::close(raw) };
+        close_raw_fds(raw_fds_to_close);
+        return Err(err);
+    }
+    // SAFETY: the duplicate now holds the description; release the original.
+    unsafe { libc::close(raw) };
+    Ok(moved)
+}
+
 #[cfg(unix)]
 fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     use std::ffi::CString;
@@ -714,26 +751,34 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
     // Lazily-opened /dev/null, shared by all `Fd::Close` entries.
     let mut devnull_fd: Option<std::os::fd::RawFd> = None;
 
+    // Every descriptor number the child's fd table will touch. Parent-side
+    // source fds are relocated above this so that no `dup2` target and no
+    // `close` can ever land on a source — see `relocate_above`.
+    let relocation_floor = cmd.fds.keys().copied().max().unwrap_or(-1) + 1;
+
+    // Collected actions, applied after the loop in a fixed order: every dup2
+    // first, then every close. `cmd.fds` is a HashMap, so the iteration order
+    // varies per process; without this the resulting spawn would be
+    // order-dependent and therefore nondeterministic.
+    let mut dup2_actions: Vec<(std::os::fd::RawFd, i32)> = Vec::new();
+    let mut close_actions: Vec<i32> = Vec::new();
+
     for (&fd_num, fd_spec) in &cmd.fds {
         match fd_spec {
             Fd::Pipe => {
                 let (read_end, write_end) = nix::unistd::pipe().map_err(io::Error::other)?;
-                let write_raw = write_end.into_raw_fd();
+                let write_raw = relocate_above(write_end.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
                 raw_fds_to_close.push(write_raw);
-                file_actions.add_dup2(write_raw, fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
+                dup2_actions.push((write_raw, fd_num));
                 let parent_file = File::from(read_end);
                 set_cloexec(&parent_file);
                 pipes.insert(fd_num, parent_file);
             }
             Fd::InputPipe => {
                 let (read_end, write_end) = nix::unistd::pipe().map_err(io::Error::other)?;
-                let read_raw = read_end.into_raw_fd();
+                let read_raw = relocate_above(read_end.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
                 raw_fds_to_close.push(read_raw);
-                file_actions.add_dup2(read_raw, fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
+                dup2_actions.push((read_raw, fd_num));
                 let parent_file = File::from(write_end);
                 set_cloexec(&parent_file);
                 pipes.insert(fd_num, parent_file);
@@ -750,31 +795,23 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                     attrs.output_flags.remove(OutputFlags::ONLCR);
                     termios::tcsetattr(&pty.slave, SetArg::TCSANOW, &attrs).map_err(io::Error::other)?;
                 }
-                let slave_raw = pty.slave.into_raw_fd();
+                // Relocated above every target, so the "close the slave in the
+                // child" action below can never destroy a target fd.
+                let slave_raw = relocate_above(pty.slave.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
                 raw_fds_to_close.push(slave_raw);
-                file_actions.add_dup2(slave_raw, fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
+                dup2_actions.push((slave_raw, fd_num));
                 // Close the original slave fd in the child after dup2. Without
                 // this, the child holds an extra reference to the PTY slave,
                 // preventing EOF detection on the master.
-                // Skip if slave_raw == fd_num: dup2 is a no-op (POSIX) and
-                // closing would destroy the target fd.
-                if slave_raw != fd_num {
-                    file_actions.add_close(slave_raw).inspect_err(|_| {
-                        close_raw_fds(&raw_fds_to_close);
-                    })?;
-                }
+                close_actions.push(slave_raw);
                 let master_file = File::from(pty.master);
                 set_cloexec(&master_file);
                 pipes.insert(fd_num, master_file);
             }
             Fd::File(file) => {
-                let raw_fd = file.try_clone()?.into_raw_fd();
+                let raw_fd = relocate_above(file.try_clone()?.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
                 raw_fds_to_close.push(raw_fd);
-                file_actions.add_dup2(raw_fd, fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
+                dup2_actions.push((raw_fd, fd_num));
             }
             Fd::Close => {
                 // A bare `addclose` is not usable here: if `fd_num` is not open
@@ -793,20 +830,32 @@ fn spawn_impl(cmd: CommandEx) -> io::Result<ChildEx> {
                             .inspect_err(|_| {
                                 close_raw_fds(&raw_fds_to_close);
                             })?;
-                        let raw = file.into_raw_fd();
+                        let raw = relocate_above(file.into_raw_fd(), relocation_floor, &raw_fds_to_close)?;
                         raw_fds_to_close.push(raw);
                         devnull_fd = Some(raw);
                         raw
                     }
                 };
-                file_actions.add_dup2(devnull_raw, fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
-                file_actions.add_close(fd_num).inspect_err(|_| {
-                    close_raw_fds(&raw_fds_to_close);
-                })?;
+                dup2_actions.push((devnull_raw, fd_num));
+                close_actions.push(fd_num);
             }
         }
+    }
+
+    // Deterministic order: all dup2s, then all closes. Safe because every
+    // source is above `relocation_floor` and every dup2 target is below it, so
+    // no close in the second pass can invalidate a source used in the first.
+    dup2_actions.sort_unstable();
+    close_actions.sort_unstable();
+    for (src, dst) in dup2_actions {
+        file_actions.add_dup2(src, dst).inspect_err(|_| {
+            close_raw_fds(&raw_fds_to_close);
+        })?;
+    }
+    for fd in close_actions {
+        file_actions.add_close(fd).inspect_err(|_| {
+            close_raw_fds(&raw_fds_to_close);
+        })?;
     }
 
     // Set child CWD. Prefer addchdir_np (no process-global side effects);

--- a/src/exec/command_ex.rs
+++ b/src/exec/command_ex.rs
@@ -33,6 +33,18 @@ pub(crate) enum Fd {
     Close,
 }
 
+/// Whether a descriptor the script closed should also be closed in the child.
+///
+/// Descriptors 3+ on every platform. Standard descriptors only on Unix: routing
+/// 0-2 to [`Fd::Close`] on Windows would take an untested path through
+/// `STARTF_USESTDHANDLES`, and nobody working on this can run Windows. Gating
+/// leaves that platform behaving exactly as it did before — see issue #46,
+/// which also records that Windows therefore keeps the pre-existing
+/// `cmd 1>&-` divergence rather than gaining a new one.
+pub(crate) fn close_in_child(fd: i32) -> bool {
+    fd > 2 || cfg!(unix)
+}
+
 // CommandEx ===========================================================================================================
 
 /// Description of a child process to spawn. All fields are public; callers

--- a/src/exec/command_ex/spawn_windows.rs
+++ b/src/exec/command_ex/spawn_windows.rs
@@ -97,6 +97,10 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
                 make_inheritable(handle)?;
                 handle_table.insert(fd_num, (handle, FOPEN));
             }
+            // Absent from `handle_table` is exactly "closed": fds 3+ reach the
+            // child only through `build_lpreserved2`, and a number with no
+            // entry gets a zero flags byte, which the CRT reads as not open.
+            Fd::Close => {}
             Fd::Pty => unreachable!("Pty fds are handled by spawn_with_conpty"),
         }
     }
@@ -396,7 +400,8 @@ fn spawn_with_conpty(cmd: CommandEx) -> io::Result<ChildEx> {
 
     for (&fd_num, fd_spec) in &cmd.fds {
         match fd_spec {
-            Fd::Pty => {} // Handled by ConPTY
+            Fd::Close => {} // Absent from the handle table means closed.
+            Fd::Pty => {}   // Handled by ConPTY
             Fd::Pipe => {
                 let (read_handle, write_handle) = create_pipe()?;
                 let read_file = unsafe { File::from_raw_handle(read_handle.0 as _) };

--- a/src/exec/command_ex/spawn_windows.rs
+++ b/src/exec/command_ex/spawn_windows.rs
@@ -71,6 +71,11 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
 
     let mut pipes: HashMap<i32, File> = HashMap::new();
     let mut handle_table: HashMap<i32, (HANDLE, u8)> = HashMap::new();
+    // Standard descriptors the script closed. Absence from `handle_table` is
+    // not enough for 0-2: the STARTUPINFOW block below fills any missing one
+    // from the parent's `GetStdHandle`, which would hand the child the *host's*
+    // console or pipe — the very escape the close exists to prevent.
+    let mut closed_std: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
     // Process the fd table: create pipes and collect handles.
     for (&fd_num, fd_spec) in &cmd.fds {
@@ -97,10 +102,15 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
                 make_inheritable(handle)?;
                 handle_table.insert(fd_num, (handle, FOPEN));
             }
-            // Absent from `handle_table` is exactly "closed": fds 3+ reach the
-            // child only through `build_lpreserved2`, and a number with no
-            // entry gets a zero flags byte, which the CRT reads as not open.
-            Fd::Close => {}
+            // For fds 3+, absence from `handle_table` is exactly "closed":
+            // they reach the child only through `build_lpreserved2`, and a
+            // number with no entry gets a zero flags byte, which the CRT reads
+            // as not open. Descriptors 0-2 are different — see `closed_std`.
+            Fd::Close => {
+                if fd_num <= 2 {
+                    closed_std.insert(fd_num);
+                }
+            }
             Fd::Pty => unreachable!("Pty fds are handled by spawn_with_conpty"),
         }
     }
@@ -113,22 +123,30 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
     // in the table, fall back to the parent's current std handles via
     // GetStdHandle (not INVALID_HANDLE_VALUE, which would leave the child
     // with a broken handle).
-    if handle_table.contains_key(&0) || handle_table.contains_key(&1) || handle_table.contains_key(&2) {
+    if handle_table.contains_key(&0)
+        || handle_table.contains_key(&1)
+        || handle_table.contains_key(&2)
+        || !closed_std.is_empty()
+    {
         use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
 
+        // A closed standard descriptor gets INVALID_HANDLE_VALUE: the child has
+        // no handle there, which is what `1>&-` asks for. Anything still
+        // unspecified falls back to the parent's, as before.
+        let std_handle = |fd: i32, id| {
+            if closed_std.contains(&fd) {
+                return INVALID_HANDLE_VALUE;
+            }
+            handle_table
+                .get(&fd)
+                .map(|h| h.0)
+                .unwrap_or_else(|| unsafe { GetStdHandle(id) }.unwrap_or(INVALID_HANDLE_VALUE))
+        };
+
         si.dwFlags |= STARTF_USESTDHANDLES;
-        si.hStdInput = handle_table
-            .get(&0)
-            .map(|h| h.0)
-            .unwrap_or_else(|| unsafe { GetStdHandle(STD_INPUT_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
-        si.hStdOutput = handle_table
-            .get(&1)
-            .map(|h| h.0)
-            .unwrap_or_else(|| unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
-        si.hStdError = handle_table
-            .get(&2)
-            .map(|h| h.0)
-            .unwrap_or_else(|| unsafe { GetStdHandle(STD_ERROR_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
+        si.hStdInput = std_handle(0, STD_INPUT_HANDLE);
+        si.hStdOutput = std_handle(1, STD_OUTPUT_HANDLE);
+        si.hStdError = std_handle(2, STD_ERROR_HANDLE);
     }
 
     // Build lpReserved2 for FDs 3+ (CRT fd table).

--- a/src/exec/command_ex/spawn_windows.rs
+++ b/src/exec/command_ex/spawn_windows.rs
@@ -71,11 +71,6 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
 
     let mut pipes: HashMap<i32, File> = HashMap::new();
     let mut handle_table: HashMap<i32, (HANDLE, u8)> = HashMap::new();
-    // Standard descriptors the script closed. Absence from `handle_table` is
-    // not enough for 0-2: the STARTUPINFOW block below fills any missing one
-    // from the parent's `GetStdHandle`, which would hand the child the *host's*
-    // console or pipe — the very escape the close exists to prevent.
-    let mut closed_std: std::collections::HashSet<i32> = std::collections::HashSet::new();
 
     // Process the fd table: create pipes and collect handles.
     for (&fd_num, fd_spec) in &cmd.fds {
@@ -102,15 +97,13 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
                 make_inheritable(handle)?;
                 handle_table.insert(fd_num, (handle, FOPEN));
             }
-            // For fds 3+, absence from `handle_table` is exactly "closed":
-            // they reach the child only through `build_lpreserved2`, and a
-            // number with no entry gets a zero flags byte, which the CRT reads
-            // as not open. Descriptors 0-2 are different — see `closed_std`.
-            Fd::Close => {
-                if fd_num <= 2 {
-                    closed_std.insert(fd_num);
-                }
-            }
+            // Absence from `handle_table` is exactly "closed": fds 3+ reach the
+            // child only through `build_lpreserved2`, and a number with no
+            // entry gets a zero flags byte, which the CRT reads as not open.
+            // Descriptors 0-2 never arrive here — `close_in_child` gates them
+            // off on Windows (issue #46) precisely because the alternative
+            // path through `STARTF_USESTDHANDLES` below is unexercised.
+            Fd::Close => {}
             Fd::Pty => unreachable!("Pty fds are handled by spawn_with_conpty"),
         }
     }
@@ -123,30 +116,22 @@ pub(super) fn spawn_impl(mut cmd: CommandEx) -> io::Result<ChildEx> {
     // in the table, fall back to the parent's current std handles via
     // GetStdHandle (not INVALID_HANDLE_VALUE, which would leave the child
     // with a broken handle).
-    if handle_table.contains_key(&0)
-        || handle_table.contains_key(&1)
-        || handle_table.contains_key(&2)
-        || !closed_std.is_empty()
-    {
+    if handle_table.contains_key(&0) || handle_table.contains_key(&1) || handle_table.contains_key(&2) {
         use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
 
-        // A closed standard descriptor gets INVALID_HANDLE_VALUE: the child has
-        // no handle there, which is what `1>&-` asks for. Anything still
-        // unspecified falls back to the parent's, as before.
-        let std_handle = |fd: i32, id| {
-            if closed_std.contains(&fd) {
-                return INVALID_HANDLE_VALUE;
-            }
-            handle_table
-                .get(&fd)
-                .map(|h| h.0)
-                .unwrap_or_else(|| unsafe { GetStdHandle(id) }.unwrap_or(INVALID_HANDLE_VALUE))
-        };
-
         si.dwFlags |= STARTF_USESTDHANDLES;
-        si.hStdInput = std_handle(0, STD_INPUT_HANDLE);
-        si.hStdOutput = std_handle(1, STD_OUTPUT_HANDLE);
-        si.hStdError = std_handle(2, STD_ERROR_HANDLE);
+        si.hStdInput = handle_table
+            .get(&0)
+            .map(|h| h.0)
+            .unwrap_or_else(|| unsafe { GetStdHandle(STD_INPUT_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
+        si.hStdOutput = handle_table
+            .get(&1)
+            .map(|h| h.0)
+            .unwrap_or_else(|| unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
+        si.hStdError = handle_table
+            .get(&2)
+            .map(|h| h.0)
+            .unwrap_or_else(|| unsafe { GetStdHandle(STD_ERROR_HANDLE) }.unwrap_or(INVALID_HANDLE_VALUE));
     }
 
     // Build lpReserved2 for FDs 3+ (CRT fd table).

--- a/src/exec/command_ex_tests.rs
+++ b/src/exec/command_ex_tests.rs
@@ -197,6 +197,72 @@ mod posix_quoting {
         assert_eq!(std::fs::read_to_string(&file_path).unwrap(), "hello\n");
     }
 
+    /// `Fd::Close` must make the number unusable in the child even though the
+    /// parent has it open — otherwise `posix_spawn` inherits it and a script
+    /// that closed the descriptor still reaches whatever the host had there.
+    ///
+    /// The descriptor number comes from `into_raw_fd`, never `dup2` onto a
+    /// literal: the test process has descriptors of its own.
+    #[skuld::test]
+    fn spawn_close_fd_denies_inherited_descriptor(#[fixture(temp_dir)] dir: &Path) {
+        use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd};
+
+        let file_path = dir.join("closed.txt");
+        let file = std::fs::File::create(&file_path).unwrap();
+        // Rust opens files O_CLOEXEC; dup(2) clears it, so the child would
+        // genuinely inherit this were it not for `Fd::Close`.
+        let inheritable = crate::exec::buffered_file::dup_process_fd(file.as_raw_fd()).unwrap();
+        drop(file);
+        let raw = inheritable.into_raw_fd();
+
+        let mut cmd = super::super::CommandEx::new(vec![
+            OsString::from("sh"),
+            OsString::from("-c"),
+            OsString::from(format!("echo escaped >&{raw}")),
+        ]);
+        cmd.fds.insert(raw, super::super::Fd::Close);
+        let mut child = cmd.spawn().expect("spawn failed");
+        let status = child.wait().expect("wait failed");
+
+        assert_ne!(status, 0, "the child should fail on a closed descriptor");
+        assert_eq!(
+            std::fs::read_to_string(&file_path).unwrap(),
+            "",
+            "a closed descriptor must not be inherited"
+        );
+
+        // SAFETY: `raw` came from `into_raw_fd` and is still open in this process.
+        drop(unsafe { std::fs::File::from_raw_fd(raw) });
+    }
+
+    /// `Fd::Close` on a number that is *not* open must still spawn.
+    ///
+    /// A bare `posix_spawn_file_actions_addclose` fails the whole spawn with
+    /// EBADF in that case (verified on macOS), so the implementation dups
+    /// /dev/null onto the number first. Without that, any script closing a
+    /// descriptor it never opened would break every later external command.
+    #[skuld::test]
+    fn spawn_close_fd_on_unopened_number_still_spawns() {
+        use std::os::fd::{FromRawFd, IntoRawFd};
+
+        // Take a number from the OS, then release it: nothing else in this
+        // process can be holding it at the moment we release it, and the
+        // dup2-then-close construction is correct whether or not it is reused.
+        let placeholder = std::fs::File::open("/dev/null").unwrap();
+        let raw = placeholder.into_raw_fd();
+        // SAFETY: `raw` came from `into_raw_fd`; dropping closes it.
+        drop(unsafe { std::fs::File::from_raw_fd(raw) });
+
+        let mut cmd = super::super::CommandEx::new(vec![
+            OsString::from("sh"),
+            OsString::from("-c"),
+            OsString::from("exit 7"),
+        ]);
+        cmd.fds.insert(raw, super::super::Fd::Close);
+        let mut child = cmd.spawn().expect("spawn must succeed for an unopened fd");
+        assert_eq!(child.wait().expect("wait failed"), 7);
+    }
+
     /// Verify that `CommandEx.cwd` sets the child's working directory.
     #[skuld::test]
     fn spawn_with_cwd(#[fixture(temp_dir)] dir: &Path) {

--- a/src/exec/compound.rs
+++ b/src/exec/compound.rs
@@ -120,7 +120,7 @@ impl Executor {
                 let word_list = if let Some(words) = words {
                     let mut list = Vec::new();
                     for word in words {
-                        let fields = self.expand_word_to_fields(word)?;
+                        let fields = self.expand_word_to_fields(word, io)?;
                         list.extend(fields);
                     }
                     list
@@ -149,14 +149,14 @@ impl Executor {
             }
 
             CompoundCommand::CaseClause { word, arms, .. } => {
-                let expanded = self.expand_word(word)?;
+                let expanded = self.expand_word(word, io)?;
                 let mut status = 0;
 
                 for arm in arms {
                     let mut matched = false;
                     let locale = super::locale::ctype_locale(&self.env);
                     for pattern in &arm.patterns {
-                        let pat = self.expand_word(pattern)?;
+                        let pat = self.expand_word(pattern, io)?;
                         if super::pattern::shell_pattern_match(&expanded, &pat, &locale) {
                             matched = true;
                             break;

--- a/src/exec/external.rs
+++ b/src/exec/external.rs
@@ -12,7 +12,7 @@
 use std::io::Write;
 
 use crate::exec::child_io;
-use crate::exec::command_ex::{CommandEx, Fd};
+use crate::exec::command_ex::{close_in_child, CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::redirect::ActiveRedirects;
@@ -66,7 +66,7 @@ impl Executor {
         // Leaving them out of the table is not enough: posix_spawn inherits
         // every fd it is not told about, so the child would get whatever the
         // *host* process has at that number.
-        for &fd in io.closed_fds() {
+        for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
             child_cmd.fds.insert(fd, Fd::Close);
         }
 
@@ -97,7 +97,7 @@ impl Executor {
         // the persistent set so a per-command reopen can override it.
         // Standard descriptors are included: `cmd 1>&-` must leave the child
         // without a stdout rather than with a pipe to the host's (issue #41).
-        for &fd in &active.closed_fds {
+        for &fd in active.closed_fds.iter().filter(|&&fd| close_in_child(fd)) {
             child_cmd.fds.insert(fd, Fd::Close);
         }
 

--- a/src/exec/external.rs
+++ b/src/exec/external.rs
@@ -62,6 +62,14 @@ impl Executor {
             }
         }
 
+        // Descriptors the script closed must be closed in the child too.
+        // Leaving them out of the table is not enough: posix_spawn inherits
+        // every fd it is not told about, so the child would get whatever the
+        // *host* process has at that number.
+        for &fd in io.closed_fds() {
+            child_cmd.fds.insert(fd, Fd::Close);
+        }
+
         // Per-command redirects override persistent ones: FDs 0-2 from
         // redirect list, then FDs 3+ from extra_fds.
         if let Some(ref file) = active.stdin {
@@ -83,6 +91,14 @@ impl Executor {
             child_cmd
                 .fds
                 .insert(fd, Fd::File(file.try_clone().map_err(ExecError::Io)?));
+        }
+        // Per-command closes, e.g. `cmd 3>&-`. Applied after the per-command
+        // opens so that within one redirect list the last word wins, and after
+        // the persistent set so a per-command reopen can override it.
+        // Standard descriptors are included: `cmd 1>&-` must leave the child
+        // without a stdout rather than with a pipe to the host's (issue #41).
+        for &fd in &active.closed_fds {
+            child_cmd.fds.insert(fd, Fd::Close);
         }
 
         // Set up stdout/stderr for the child. For unredirected fds:

--- a/src/exec/external.rs
+++ b/src/exec/external.rs
@@ -48,7 +48,7 @@ impl Executor {
             .map(|(k, v)| (k.into(), v.into()))
             .collect();
         for assignment in assignments {
-            let value = self.expand_scalar_assignment(assignment)?;
+            let value = self.expand_scalar_assignment(assignment, io)?;
             env.insert(assignment.name.clone().into(), value.into());
         }
         child_cmd.env = env;

--- a/src/exec/external.rs
+++ b/src/exec/external.rs
@@ -12,7 +12,7 @@
 use std::io::Write;
 
 use crate::exec::child_io;
-use crate::exec::command_ex::{close_in_child, CommandEx, Fd};
+use crate::exec::command_ex::{CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::redirect::ActiveRedirects;
@@ -66,8 +66,8 @@ impl Executor {
         // Leaving them out of the table is not enough: posix_spawn inherits
         // every fd it is not told about, so the child would get whatever the
         // *host* process has at that number.
-        for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
-            child_cmd.fds.insert(fd, Fd::Close);
+        for &fd in io.closed_fds() {
+            child_cmd.close_fd_in_child(fd);
         }
 
         // Per-command redirects override persistent ones: FDs 0-2 from
@@ -97,8 +97,8 @@ impl Executor {
         // the persistent set so a per-command reopen can override it.
         // Standard descriptors are included: `cmd 1>&-` must leave the child
         // without a stdout rather than with a pipe to the host's (issue #41).
-        for &fd in active.closed_fds.iter().filter(|&&fd| close_in_child(fd)) {
-            child_cmd.fds.insert(fd, Fd::Close);
+        for &fd in &active.closed_fds {
+            child_cmd.close_fd_in_child(fd);
         }
 
         // Set up stdout/stderr for the child. For unredirected fds:

--- a/src/exec/io_context.rs
+++ b/src/exec/io_context.rs
@@ -21,6 +21,18 @@ use crate::exec::platform::is_file_terminal;
 /// not a type-level constraint. TTY-ness is queried on-demand.
 pub struct IoContext {
     fds: HashMap<i32, File>,
+    /// Fds the script explicitly closed with `N>&-` / `N<&-`.
+    ///
+    /// Distinct from simply being absent from `fds`. An absent fd is one the
+    /// shell never touched, which it may still resolve against the host
+    /// process's real fd table — that is ordinary POSIX inheritance and bash
+    /// does the same. A *closed* fd must not be resolvable that way, and must
+    /// not be inherited by children.
+    ///
+    /// thaum never calls `close(2)` on the host's descriptor: it is not ours to
+    /// close. Recording the close and refusing to hand the number out is
+    /// observably equivalent for the script and leaves the embedder intact.
+    closed: HashSet<i32>,
     /// Fds that should report as terminals regardless of the underlying handle.
     /// Used in tests to exercise the PTY code path with pipe-backed fds.
     tty_overrides: HashSet<i32>,
@@ -31,6 +43,7 @@ impl IoContext {
     pub fn new(fds: HashMap<i32, File>) -> Self {
         IoContext {
             fds,
+            closed: HashSet::new(),
             tty_overrides: HashSet::new(),
         }
     }
@@ -46,13 +59,48 @@ impl IoContext {
     }
 
     /// Insert or replace a file descriptor.
+    ///
+    /// Reopening a number clears any closed marker: `exec 3>&-; exec 3>file`
+    /// leaves fd 3 usable again, in thaum as in bash.
     pub fn set_fd(&mut self, fd: i32, file: File) {
+        self.closed.remove(&fd);
         self.fds.insert(fd, file);
     }
 
     /// Remove a file descriptor, returning it if present.
+    ///
+    /// Bookkeeping only — this does **not** mark the fd closed. Use
+    /// [`close_fd`](IoContext::close_fd) for `N>&-`.
     pub fn remove_fd(&mut self, fd: i32) -> Option<File> {
         self.fds.remove(&fd)
+    }
+
+    /// Mark a file descriptor as explicitly closed by the script.
+    ///
+    /// Drops any handle the shell held and records the number so it is neither
+    /// resolvable by a later `>&N` nor inherited by a spawned child.
+    pub fn close_fd(&mut self, fd: i32) {
+        self.fds.remove(&fd);
+        self.closed.insert(fd);
+    }
+
+    /// Whether the script explicitly closed this descriptor.
+    pub fn is_closed(&self, fd: i32) -> bool {
+        self.closed.contains(&fd)
+    }
+
+    /// Every descriptor the script explicitly closed.
+    pub fn closed_fds(&self) -> &HashSet<i32> {
+        &self.closed
+    }
+
+    /// Set or clear the closed marker directly. For redirect save/restore only.
+    pub fn set_closed_marker(&mut self, fd: i32, closed: bool) {
+        if closed {
+            self.closed.insert(fd);
+        } else {
+            self.closed.remove(&fd);
+        }
     }
 
     /// Clone (dup) a file descriptor's OS handle.
@@ -105,6 +153,7 @@ impl IoContext {
     /// Used by redirect apply/restore: save the original, set the redirect,
     /// then later restore via [`restore()`](IoContext::restore).
     pub fn save_and_set(&mut self, fd: i32, file: File) -> Option<File> {
+        self.closed.remove(&fd);
         self.fds.insert(fd, file)
     }
 
@@ -113,6 +162,7 @@ impl IoContext {
     /// - `saved = Some(file)`: put back the original fd.
     /// - `saved = None`: the fd was newly added by a redirect — remove it.
     pub fn restore(&mut self, fd: i32, saved: Option<File>) {
+        self.closed.remove(&fd);
         match saved {
             Some(file) => {
                 self.fds.insert(fd, file);

--- a/src/exec/io_context_tests.rs
+++ b/src/exec/io_context_tests.rs
@@ -182,3 +182,46 @@ fn io_context_try_clone_fd() {
     drop(cloned);
     drop(capture.finish(io));
 }
+
+// Explicitly closed descriptors =======================================================================================
+
+#[skuld::test]
+fn close_fd_marks_closed_and_drops_handle() {
+    let mut io = IoContext::from_process();
+    io.set_fd(7, super::open_null_device());
+    io.close_fd(7);
+    assert!(io.fd(7).is_none(), "close_fd should drop the handle");
+    assert!(io.is_closed(7), "close_fd should record the close");
+    assert!(io.closed_fds().contains(&7));
+}
+
+#[skuld::test]
+fn set_fd_clears_closed_marker() {
+    // Derived from bash: `exec 3>&-; exec 3>r1; echo re >&3` writes to r1, so
+    // a close is not permanent — reopening the number restores it.
+    let mut io = IoContext::from_process();
+    io.close_fd(7);
+    io.set_fd(7, super::open_null_device());
+    assert!(!io.is_closed(7), "reopening a descriptor must clear the closed marker");
+    assert!(io.fd(7).is_some());
+}
+
+#[skuld::test]
+fn remove_fd_does_not_mark_closed() {
+    // Removal is bookkeeping; closing is a statement about the OS. Conflating
+    // them would make every restored redirect look like a close.
+    let mut io = IoContext::from_process();
+    io.set_fd(7, super::open_null_device());
+    io.remove_fd(7);
+    assert!(io.fd(7).is_none());
+    assert!(!io.is_closed(7), "remove_fd must not imply a close");
+}
+
+#[skuld::test]
+fn set_closed_marker_round_trips() {
+    let mut io = IoContext::from_process();
+    io.set_closed_marker(7, true);
+    assert!(io.is_closed(7));
+    io.set_closed_marker(7, false);
+    assert!(!io.is_closed(7));
+}

--- a/src/exec/pipeline.rs
+++ b/src/exec/pipeline.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 
 use crate::ast::Expression;
-use crate::exec::command_ex::{close_in_child, ChildEx, CommandEx, Fd};
+use crate::exec::command_ex::{ChildEx, CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::Executor;
@@ -185,8 +185,8 @@ fn spawn_pipeline_stage(
 
             // Descriptors the script closed must not reach a pipeline stage
             // either — posix_spawn would otherwise inherit the host's.
-            for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
-                child_cmd.fds.insert(fd, Fd::Close);
+            for &fd in io.closed_fds() {
+                child_cmd.close_fd_in_child(fd);
             }
 
             if let Some(prev_out) = stdin {

--- a/src/exec/pipeline.rs
+++ b/src/exec/pipeline.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 
 use crate::ast::Expression;
-use crate::exec::command_ex::{ChildEx, CommandEx, Fd};
+use crate::exec::command_ex::{close_in_child, ChildEx, CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::Executor;
@@ -185,7 +185,7 @@ fn spawn_pipeline_stage(
 
             // Descriptors the script closed must not reach a pipeline stage
             // either — posix_spawn would otherwise inherit the host's.
-            for &fd in io.closed_fds() {
+            for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
                 child_cmd.fds.insert(fd, Fd::Close);
             }
 

--- a/src/exec/pipeline.rs
+++ b/src/exec/pipeline.rs
@@ -183,6 +183,12 @@ fn spawn_pipeline_stage(
                 }
             }
 
+            // Descriptors the script closed must not reach a pipeline stage
+            // either — posix_spawn would otherwise inherit the host's.
+            for &fd in io.closed_fds() {
+                child_cmd.fds.insert(fd, Fd::Close);
+            }
+
             if let Some(prev_out) = stdin {
                 child_cmd.fds.insert(0, Fd::File(prev_out));
             }

--- a/src/exec/pipeline.rs
+++ b/src/exec/pipeline.rs
@@ -95,7 +95,7 @@ fn spawn_pipeline_stage(
 
             if expanded_args.is_empty() {
                 for assignment in &cmd.assignments {
-                    executor.execute_assignment(assignment)?;
+                    executor.execute_assignment(assignment, io)?;
                 }
                 return Ok(None);
             }
@@ -171,7 +171,7 @@ fn spawn_pipeline_stage(
             child_cmd.env = env;
 
             for assignment in &cmd.assignments {
-                let value = executor.expand_scalar_assignment(assignment)?;
+                let value = executor.expand_scalar_assignment(assignment, io)?;
                 child_cmd.env.insert(assignment.name.clone().into(), value.into());
             }
 

--- a/src/exec/redirect.rs
+++ b/src/exec/redirect.rs
@@ -67,12 +67,14 @@ impl ActiveRedirects {
             let was_closed = io.is_closed(fd);
             if fd <= 2 {
                 // Replace fds 0-2 with /dev/null instead of removing, so
-                // downstream code always finds a valid handle for these fds.
-                // The shell's own writes to a closed 0-2 therefore succeed
-                // where bash reports EBADF — tracked separately as issue #41;
-                // the child half is handled at the spawn sites.
+                // downstream code always finds a valid handle for these fds,
+                // then mark the number closed so children are still denied it.
+                // The shell's own writes therefore succeed where bash reports
+                // EBADF — that half is issue #41.
                 let null = crate::exec::io_context::open_null_device();
-                saved.push(fd, was_closed, io.save_and_set(fd, null));
+                let prev = io.save_and_set(fd, null);
+                io.set_closed_marker(fd, true);
+                saved.push(fd, was_closed, prev);
             } else {
                 let prev = io.remove_fd(fd);
                 io.close_fd(fd);
@@ -244,8 +246,8 @@ impl Executor {
                     let resolved = self.resolve_path(&path);
                     let file = File::create(&resolved).map_err(|e| ExecError::BadRedirect(format!("{path}: {e}")))?;
                     let clone = file.try_clone().map_err(ExecError::Io)?;
-                    active.stdout = Some(BufferedFile::new(file));
-                    active.stderr = Some(BufferedFile::new(clone));
+                    assign_write_fd(&mut active, 1, file)?;
+                    assign_write_fd(&mut active, 2, clone)?;
                 }
                 RedirectKind::BashAppendAll(word) => {
                     // &>> file — append both stdout and stderr to file
@@ -257,8 +259,8 @@ impl Executor {
                         .open(&resolved)
                         .map_err(|e| ExecError::BadRedirect(format!("{path}: {e}")))?;
                     let clone = file.try_clone().map_err(ExecError::Io)?;
-                    active.stdout = Some(BufferedFile::new(file));
-                    active.stderr = Some(BufferedFile::new(clone));
+                    assign_write_fd(&mut active, 1, file)?;
+                    assign_write_fd(&mut active, 2, clone)?;
                 }
             }
         }
@@ -271,7 +273,10 @@ impl Executor {
 /// close N". A bare `-` is the plain close form and is handled by the caller.
 fn parse_move_target(target: &str) -> Option<i32> {
     let digits = target.strip_suffix('-')?;
-    if digits.is_empty() {
+    // Digits only. `str::parse` would accept a leading `-`, so `3>&-3-` would
+    // yield -3 and carry a negative descriptor into the closed set and on into
+    // `dup2`. bash rejects the word instead.
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
         return None;
     }
     digits.parse::<i32>().ok()
@@ -310,25 +315,31 @@ fn assign_write_fd(active: &mut ActiveRedirects, fd: i32, file: File) -> Result<
     Ok(())
 }
 
-/// Close a write FD by assigning a sink.
+/// Close a write FD (`N>&-`).
 fn close_write_fd(active: &mut ActiveRedirects, fd: i32) {
-    active.closed_fds.insert(fd);
-    match fd {
-        // For FDs 0-2, mark as closed. apply() will replace them with
-        // /dev/null instead of removing them from the IoContext.
-        1 => active.stdout = None,
-        2 => active.stderr = None,
-        n => {
-            active.extra_fds.remove(&n);
-        }
-    }
+    clear_fd_slot(active, fd);
 }
 
-/// Close a read FD.
+/// Close a read FD (`N<&-`).
 fn close_read_fd(active: &mut ActiveRedirects, fd: i32) {
+    clear_fd_slot(active, fd);
+}
+
+/// Drop whatever this redirect list has assigned to `fd` and mark it closed.
+///
+/// The slot is chosen by descriptor *number*, not by the direction of the
+/// closing operator: `0>&-` and `0<&-` both close descriptor 0. Keying off the
+/// operator instead left `0>&-` routing to `extra_fds` while stdin stayed
+/// assigned, so `exec 0<src 0>&-; read x` still read the file (bash: EBADF).
+///
+/// For FDs 0-2 the slot is only cleared here; `apply()` and `adopt_redirects`
+/// substitute /dev/null so downstream code always finds a valid handle.
+fn clear_fd_slot(active: &mut ActiveRedirects, fd: i32) {
     active.closed_fds.insert(fd);
     match fd {
         0 => active.stdin = None,
+        1 => active.stdout = None,
+        2 => active.stderr = None,
         n => {
             active.extra_fds.remove(&n);
         }

--- a/src/exec/redirect.rs
+++ b/src/exec/redirect.rs
@@ -333,7 +333,8 @@ fn close_read_fd(active: &mut ActiveRedirects, fd: i32) {
 /// assigned, so `exec 0<src 0>&-; read x` still read the file (bash: EBADF).
 ///
 /// For FDs 0-2 the slot is only cleared here; `apply()` and `adopt_redirects`
-/// substitute /dev/null so downstream code always finds a valid handle.
+/// substitute /dev/null so downstream code always finds a valid handle, and
+/// record the closed marker separately so children are still denied the number.
 fn clear_fd_slot(active: &mut ActiveRedirects, fd: i32) {
     active.closed_fds.insert(fd);
     match fd {

--- a/src/exec/redirect.rs
+++ b/src/exec/redirect.rs
@@ -52,30 +52,37 @@ impl ActiveRedirects {
     pub fn apply(&mut self, io: &mut IoContext) -> SavedFds {
         let mut saved = SavedFds::new();
         if let Some(f) = self.stdin.take() {
-            saved.push(0, io.save_and_set(0, f.into_inner()));
+            saved.push(0, io.is_closed(0), io.save_and_set(0, f.into_inner()));
         }
         if let Some(f) = self.stdout.take() {
-            saved.push(1, io.save_and_set(1, f.into_inner()));
+            saved.push(1, io.is_closed(1), io.save_and_set(1, f.into_inner()));
         }
         if let Some(f) = self.stderr.take() {
-            saved.push(2, io.save_and_set(2, f.into_inner()));
+            saved.push(2, io.is_closed(2), io.save_and_set(2, f.into_inner()));
         }
         for (fd, file) in self.extra_fds.drain() {
-            saved.push(fd, io.save_and_set(fd, file.into_inner()));
+            saved.push(fd, io.is_closed(fd), io.save_and_set(fd, file.into_inner()));
         }
         for &fd in &self.closed_fds {
+            let was_closed = io.is_closed(fd);
             if fd <= 2 {
                 // Replace fds 0-2 with /dev/null instead of removing, so
                 // downstream code always finds a valid handle for these fds.
+                // The shell's own writes to a closed 0-2 therefore succeed
+                // where bash reports EBADF — tracked separately as issue #41;
+                // the child half is handled at the spawn sites.
                 let null = crate::exec::io_context::open_null_device();
-                saved.push(fd, io.save_and_set(fd, null));
+                saved.push(fd, was_closed, io.save_and_set(fd, null));
             } else {
-                saved.push(fd, io.remove_fd(fd));
+                let prev = io.remove_fd(fd);
+                io.close_fd(fd);
+                saved.push(fd, was_closed, prev);
             }
         }
         // Clear tty overrides for all touched fds so that redirected fds
         // don't falsely report as terminals.
-        for &(fd, _) in &saved.fds {
+        let touched: Vec<i32> = saved.fds.iter().map(|e| e.fd).collect();
+        for fd in touched {
             if io.has_tty_override(fd) {
                 saved.saved_tty_overrides.insert(fd);
                 io.clear_tty_override(fd);
@@ -88,8 +95,17 @@ impl ActiveRedirects {
 /// Saved fd entries for restore-on-completion. Restores in reverse order
 /// to correctly unwind chained dup redirects (e.g. `exec 3>&1 1>/dev/null`).
 pub(super) struct SavedFds {
-    fds: Vec<(i32, Option<File>)>,
+    fds: Vec<SavedFd>,
     saved_tty_overrides: HashSet<i32>,
+}
+
+/// One descriptor's pre-redirect state: its handle, and whether it was already
+/// marked closed. Both must come back, or a per-command `N>&-` would leak its
+/// close into the rest of the script.
+struct SavedFd {
+    fd: i32,
+    was_closed: bool,
+    file: Option<File>,
 }
 
 impl SavedFds {
@@ -100,15 +116,16 @@ impl SavedFds {
         }
     }
 
-    fn push(&mut self, fd: i32, saved: Option<File>) {
-        self.fds.push((fd, saved));
+    fn push(&mut self, fd: i32, was_closed: bool, file: Option<File>) {
+        self.fds.push(SavedFd { fd, was_closed, file });
     }
 
     /// Restore all saved fds back to the IoContext, in reverse order.
     /// Also restores tty overrides that were cleared during apply.
     pub fn restore(self, io: &mut IoContext) {
-        for (fd, saved) in self.fds.into_iter().rev() {
-            io.restore(fd, saved);
+        for entry in self.fds.into_iter().rev() {
+            io.restore(entry.fd, entry.file);
+            io.set_closed_marker(entry.fd, entry.was_closed);
         }
         for fd in self.saved_tty_overrides {
             io.set_tty_override(fd);
@@ -171,6 +188,13 @@ impl Executor {
                     if target == "-" {
                         // Close the FD: use sink for 0-2, remove for 3+.
                         close_write_fd(&mut active, dest_fd);
+                    } else if let Some(src_fd) = parse_move_target(&target) {
+                        // `N>&M-` — move: duplicate M onto N, then close M.
+                        let cloned = clone_fd_for_write(&active, io, src_fd)?;
+                        assign_write_fd(&mut active, dest_fd, cloned)?;
+                        if src_fd != dest_fd {
+                            close_write_fd(&mut active, src_fd);
+                        }
                     } else if let Ok(src_fd) = target.parse::<i32>() {
                         let cloned = clone_fd_for_write(&active, io, src_fd)?;
                         // Cloned FDs share OS position — don't buffer reads.
@@ -184,6 +208,13 @@ impl Executor {
                     let dest_fd = fd.unwrap_or(0);
                     if target == "-" {
                         close_read_fd(&mut active, dest_fd);
+                    } else if let Some(src_fd) = parse_move_target(&target) {
+                        // `N<&M-` — move: duplicate M onto N, then close M.
+                        let cloned = clone_fd_for_read(&active, io, src_fd)?;
+                        assign_read_bf(&mut active, dest_fd, BufferedFile::passthrough(cloned))?;
+                        if src_fd != dest_fd {
+                            close_read_fd(&mut active, src_fd);
+                        }
                     } else if let Ok(src_fd) = target.parse::<i32>() {
                         let cloned = clone_fd_for_read(&active, io, src_fd)?;
                         // Cloned FDs share OS position — don't buffer reads.
@@ -236,6 +267,16 @@ impl Executor {
     }
 }
 
+/// Recognise the move form of a dup target: `N-` means "duplicate N here, then
+/// close N". A bare `-` is the plain close form and is handled by the caller.
+fn parse_move_target(target: &str) -> Option<i32> {
+    let digits = target.strip_suffix('-')?;
+    if digits.is_empty() {
+        return None;
+    }
+    digits.parse::<i32>().ok()
+}
+
 /// Assign a file to the appropriate read FD slot (buffered).
 fn assign_read_fd(active: &mut ActiveRedirects, fd: i32, file: File) -> Result<(), ExecError> {
     assign_read_bf(active, fd, BufferedFile::new(file))
@@ -243,6 +284,9 @@ fn assign_read_fd(active: &mut ActiveRedirects, fd: i32, file: File) -> Result<(
 
 /// Assign a pre-wrapped BufferedFile to the appropriate read FD slot.
 fn assign_read_bf(active: &mut ActiveRedirects, fd: i32, bf: BufferedFile) -> Result<(), ExecError> {
+    // Redirects apply left to right and the last word about a descriptor wins,
+    // so reopening a number cancels an earlier close in the same list.
+    active.closed_fds.remove(&fd);
     match fd {
         0 => active.stdin = Some(bf),
         n => {
@@ -254,6 +298,8 @@ fn assign_read_bf(active: &mut ActiveRedirects, fd: i32, bf: BufferedFile) -> Re
 
 /// Assign a file to the appropriate write FD slot (passthrough — no read buffering).
 fn assign_write_fd(active: &mut ActiveRedirects, fd: i32, file: File) -> Result<(), ExecError> {
+    // Last one wins — see `assign_read_bf`.
+    active.closed_fds.remove(&fd);
     match fd {
         1 => active.stdout = Some(BufferedFile::passthrough(file)),
         2 => active.stderr = Some(BufferedFile::passthrough(file)),
@@ -292,6 +338,14 @@ fn close_read_fd(active: &mut ActiveRedirects, fd: i32) {
 /// Clone a file descriptor from the active redirects or IoContext
 /// for use as a write target.
 fn clone_fd_for_write(active: &ActiveRedirects, io: &IoContext, src_fd: i32) -> Result<File, ExecError> {
+    // A descriptor the script closed is gone, even though the host process may
+    // still have that number open. Without this check the `dup_process_fd`
+    // fallback below reaches past the close into the embedder's fd table —
+    // which is how `exec 3>&-` ended up writing to the host's descriptor 3.
+    if active.closed_fds.contains(&src_fd) || io.is_closed(src_fd) {
+        return Err(ExecError::BadRedirect(format!("{src_fd}: bad file descriptor")));
+    }
+
     // Check active redirects first (FDs opened earlier in this redirect list).
     if let Some(file) = active.stdout.as_ref().filter(|_| src_fd == 1) {
         return file.try_clone().map_err(ExecError::Io);

--- a/src/exec/special_builtins.rs
+++ b/src/exec/special_builtins.rs
@@ -6,7 +6,7 @@
 
 use std::io::Write;
 
-use crate::exec::command_ex::{CommandEx, Fd};
+use crate::exec::command_ex::{close_in_child, CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::redirect::ActiveRedirects;
@@ -190,10 +190,10 @@ impl Executor {
         for (&fd, file) in &active.extra_fds {
             cmd.fds.insert(fd, Fd::File(file.try_clone().map_err(ExecError::Io)?));
         }
-        for &fd in io.closed_fds() {
+        for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
             cmd.fds.entry(fd).or_insert(Fd::Close);
         }
-        for &fd in &active.closed_fds {
+        for &fd in active.closed_fds.iter().filter(|&&fd| close_in_child(fd)) {
             cmd.fds.insert(fd, Fd::Close);
         }
 

--- a/src/exec/special_builtins.rs
+++ b/src/exec/special_builtins.rs
@@ -6,7 +6,7 @@
 
 use std::io::Write;
 
-use crate::exec::command_ex::{close_in_child, CommandEx, Fd};
+use crate::exec::command_ex::{CommandEx, Fd};
 use crate::exec::error::ExecError;
 use crate::exec::io_context::IoContext;
 use crate::exec::redirect::ActiveRedirects;
@@ -190,11 +190,11 @@ impl Executor {
         for (&fd, file) in &active.extra_fds {
             cmd.fds.insert(fd, Fd::File(file.try_clone().map_err(ExecError::Io)?));
         }
-        for &fd in io.closed_fds().iter().filter(|&&fd| close_in_child(fd)) {
-            cmd.fds.entry(fd).or_insert(Fd::Close);
+        for &fd in io.closed_fds() {
+            cmd.close_fd_in_child(fd);
         }
-        for &fd in active.closed_fds.iter().filter(|&&fd| close_in_child(fd)) {
-            cmd.fds.insert(fd, Fd::Close);
+        for &fd in &active.closed_fds {
+            cmd.close_fd_in_child(fd);
         }
 
         #[cfg(unix)]

--- a/src/exec/special_builtins.rs
+++ b/src/exec/special_builtins.rs
@@ -128,11 +128,13 @@ impl Executor {
                 cmd_start = i;
                 continue;
             } else if args[i].starts_with('-') {
-                // bash makes the redirections permanent even when it then
-                // rejects the option, so adopt before reporting. That is also
-                // the fail-safe direction: the write goes where the script
-                // asked rather than to whatever the host has at that number.
-                self.adopt_redirects(active, io);
+                // The redirections are *not* adopted. `exec` only makes them
+                // permanent when it succeeds, so a rejected option undoes them:
+                //   bash -c 'exec -q 3>q; echo AFTER >&3; echo rc=$?'
+                //     -> "exec: -q: invalid option", rc=1, and q is empty —
+                //        the file is created by the redirection but fd 3 is
+                //        closed again before the next command runs.
+                // Dropping `active` here reproduces that.
                 if let Some(stderr) = io.fd_mut(2) {
                     let _ = writeln!(stderr, "exec: {}: invalid option", args[i]);
                 }

--- a/src/exec/special_builtins.rs
+++ b/src/exec/special_builtins.rs
@@ -102,23 +102,18 @@ impl Executor {
 
     /// `exec` builtin: replace the current shell with the given command.
     ///
-    /// With no arguments, redirect-only mode is handled by the caller
-    /// (`execute_command`) which adopts the redirects into the IoContext
-    /// before reaching this function.
+    /// If no command word survives option parsing — a bare `exec`, `exec --`,
+    /// `exec -a name`, or a rejected option — this is redirect-only mode and
+    /// the redirections are adopted permanently into the `IoContext`.
     ///
     /// On Unix, replaces the process image via `execvp`. On other platforms,
     /// spawns the child and exits via `ExitRequested`.
     pub(super) fn builtin_exec(
         &mut self,
         args: &[String],
-        active: &mut ActiveRedirects,
+        active: ActiveRedirects,
         io: &mut IoContext,
     ) -> Result<i32, ExecError> {
-        if args.is_empty() {
-            // Redirect-only mode is handled before this function is called.
-            return Ok(0);
-        }
-
         // Parse flags.
         let mut argv0_override: Option<&str> = None;
         let mut cmd_start = 0;
@@ -133,6 +128,11 @@ impl Executor {
                 cmd_start = i;
                 continue;
             } else if args[i].starts_with('-') {
+                // bash makes the redirections permanent even when it then
+                // rejects the option, so adopt before reporting. That is also
+                // the fail-safe direction: the write goes where the script
+                // asked rather than to whatever the host has at that number.
+                self.adopt_redirects(active, io);
                 if let Some(stderr) = io.fd_mut(2) {
                     let _ = writeln!(stderr, "exec: {}: invalid option", args[i]);
                 }
@@ -144,7 +144,12 @@ impl Executor {
         }
 
         if cmd_start >= args.len() {
-            return Ok(0); // No command after flags.
+            // No command word survived option parsing, so this is redirect-only
+            // mode — `exec --`, `exec -a name`, or a bare `exec`. Dropping the
+            // redirections here is what let `exec -- 3>&1` leave the host's
+            // descriptor 3 live and receive the script's write (#16).
+            self.adopt_redirects(active, io);
+            return Ok(0);
         }
 
         let cmd_name = &args[cmd_start];
@@ -182,6 +187,12 @@ impl Executor {
         }
         for (&fd, file) in &active.extra_fds {
             cmd.fds.insert(fd, Fd::File(file.try_clone().map_err(ExecError::Io)?));
+        }
+        for &fd in io.closed_fds() {
+            cmd.fds.entry(fd).or_insert(Fd::Close);
+        }
+        for &fd in &active.closed_fds {
+            cmd.fds.insert(fd, Fd::Close);
         }
 
         #[cfg(unix)]

--- a/tests/exec.rs
+++ b/tests/exec.rs
@@ -375,6 +375,8 @@ mod bash;
 mod basic;
 #[path = "exec/brace_expansion.rs"]
 mod brace_expansion;
+#[path = "exec/descriptors.rs"]
+mod descriptors;
 #[path = "exec/expansion.rs"]
 mod expansion;
 #[path = "exec/external.rs"]

--- a/tests/exec/descriptors.rs
+++ b/tests/exec/descriptors.rs
@@ -514,6 +514,10 @@ fn closed_stdout_not_inherited_by_child(#[fixture(test_tools)] tools: &Path) {
     // gone. thaum handed the child a pipe wired to the host's stdout instead,
     // so "LEAKED" came out — a write escape on descriptor 1.
     //
+    // Unix only: `close_in_child` gates standard descriptors off on Windows,
+    // which keeps `main`'s behaviour there (issue #46). This whole module is
+    // `#![cfg(unix)]`, so the gate is invisible here.
+    //
     // Only the absence of the leak is asserted, not the child's exit status.
     // The Rust runtime reopens /dev/null over any of fds 0-2 it finds closed at
     // startup, so a Rust observer cannot report EBADF on descriptor 1 and would

--- a/tests/exec/descriptors.rs
+++ b/tests/exec/descriptors.rs
@@ -213,24 +213,37 @@ fn exec_dashdash_ends_option_parsing() {
 }
 
 #[skuld::test]
-fn exec_invalid_option_still_applies_redirections(#[fixture(temp_dir)] dir: &Path) {
-    // bash -c 'exec -q 3>&1; echo after >&3; echo rc=$?' 3>probe
-    //   -> stderr "exec: -q: invalid option" plus usage, "after" on stdout,
-    //      "rc=0" (the rc of `echo`, not of `exec`), probe empty.
-    // bash makes an `exec` redirection permanent even when the builtin then
-    // rejects an option, which is also the fail-safe direction: the write goes
-    // where the script asked rather than to the host.
-    let probe = HostFd::new(dir.join("invalid-option.txt"));
+fn exec_invalid_option_does_not_apply_redirections(#[fixture(temp_dir)] dir: &Path) {
+    // `exec` makes its redirections permanent only when it *succeeds*. A
+    // rejected option undoes them:
+    //   bash -c 'exec -q 3>q; echo AFTER >&3; echo rc=$?'
+    //     -> "exec: -q: invalid option" plus usage on stderr,
+    //        "3: Bad file descriptor", rc=1, and q is empty.
+    // The file is still created by the redirection itself; only the descriptor
+    // is dropped. An earlier revision of this test asserted the opposite,
+    // having misread `probe=[after]` — probe holding the text is precisely the
+    // evidence that fd 3 was *not* redirected.
+    let q = dir.join("invalid-option.txt");
+    let probe = HostFd::new(dir.join("invalid-option-probe.txt"));
 
-    let script = format!("exec -q {fd}>&1; echo after >&{fd}; echo rc=$?", fd = probe.fd);
+    let script = format!(
+        "exec -q {fd}>{q}; echo AFTER >&{fd}; echo rc=$?",
+        fd = probe.fd,
+        q = shell_path(&q)
+    );
     let r = exec!(&script);
-    assert_eq!(r.stdout(), "after\nrc=0\n");
     assert!(
         r.stderr().contains("invalid option"),
         "expected an invalid-option diagnostic, got: {}",
         r.stderr()
     );
-    assert_eq!(probe.contents(), "");
+    assert_eq!(
+        std::fs::read_to_string(&q).unwrap(),
+        "",
+        "a rejected option must not leave the redirection in place"
+    );
+    r.stdout();
+    r.status();
 }
 
 // `>&-` must actually close, for the shell (#17) ======================================================================
@@ -430,22 +443,67 @@ fn closed_input_fd_not_inherited(#[fixture(temp_dir)] dir: &Path, #[fixture(test
 
 #[skuld::test]
 fn close_of_unopened_fd_does_not_break_spawn(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
-    // Closing a number the shell never opened must not make the next spawn
-    // fail. On macOS a bare `posix_spawn_file_actions_addclose` against a
-    // descriptor that is not open fails the whole spawn with EBADF, so this
-    // pins the dup2-then-close construction. bash agrees the close is a no-op:
+    // Closing a number the shell never opened is a no-op in bash:
     //   bash -c 'exec 21>&-; echo ok'  ->  "ok"
-    // The command must be an *external* one, since the risk is in the spawn.
+    // It must not break the *spawn* that follows, so the command has to be an
+    // external one.
+    //
+    // Swept rather than pinned to one number. The first version of this test
+    // hardcoded 21 and passed while fd 12 failed: which numbers collide depends
+    // on where /dev/null and the capture pipes happen to land, so a single
+    // number tests almost nothing.
     let marker = dir.join("spawn-marker.txt");
     std::fs::write(&marker, "ok\n").unwrap();
+    let cat = tool(tools, "cat");
 
-    let script = format!("exec 21>&-; {ct} {t}", ct = tool(tools, "cat"), t = shell_path(&marker));
-    let r = exec!(&script);
-    assert_eq!(
-        r.stdout(),
-        "ok\n",
-        "a close of an unopened number must not break the next spawn"
-    );
+    for fd in 3..=24 {
+        let script = format!("exec {fd}>&-; {cat} {t}", t = shell_path(&marker));
+        let r = exec!(&script);
+        assert_eq!(r.stdout(), "ok\n", "closing fd {fd} broke the following spawn");
+    }
+}
+
+#[skuld::test]
+fn closing_several_fds_does_not_break_spawn(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // Two or more closes in one command is the shape that exposed the
+    // file-action collision: the shared /dev/null source could itself sit on a
+    // number that another entry closed, and `posix_spawn` then failed the whole
+    // spawn with EBADF. `bash -c 'exec 6>&- 7>&-; echo ok'` prints "ok".
+    //
+    // Repeated because the failure was nondeterministic — `cmd.fds` is a
+    // HashMap and its iteration order varies per process, so a single
+    // invocation missed it most of the time.
+    let marker = dir.join("multi-marker.txt");
+    std::fs::write(&marker, "ok\n").unwrap();
+    let cat = tool(tools, "cat");
+    let script = format!("exec 5>&- 6>&- 7>&- 8>&-; {cat} {t}", t = shell_path(&marker));
+
+    for attempt in 0..25 {
+        let r = exec!(&script);
+        assert_eq!(r.stdout(), "ok\n", "multi-close broke the spawn on attempt {attempt}");
+    }
+}
+
+#[skuld::test]
+fn closing_several_fds_does_not_break_pipeline_or_subshell(
+    #[fixture(temp_dir)] dir: &Path,
+    #[fixture(test_tools)] tools: &Path,
+) {
+    // The same collision reached the pipeline and subshell spawn paths.
+    let marker = dir.join("multi-ps-marker.txt");
+    std::fs::write(&marker, "ok\n").unwrap();
+    let cat = tool(tools, "cat");
+
+    for attempt in 0..15 {
+        let r = exec!(&format!(
+            "exec 5>&- 6>&- 7>&-; {cat} {t} | {cat}",
+            t = shell_path(&marker)
+        ));
+        assert_eq!(r.stdout(), "ok\n", "pipeline broke on attempt {attempt}");
+
+        let r = exec!(&format!("exec 5>&- 6>&- 7>&-; ({cat} {t})", t = shell_path(&marker)));
+        assert_eq!(r.stdout(), "ok\n", "subshell broke on attempt {attempt}");
+    }
 }
 
 // Closed standard descriptors are closed in the child too (#41's child half) ==========================================
@@ -466,6 +524,103 @@ fn closed_stdout_not_inherited_by_child(#[fixture(test_tools)] tools: &Path) {
     let r = exec!(&script);
     assert_eq!(r.stdout(), "done\n", "a closed stdout must not reach the host");
     r.stderr();
+}
+
+// Command substitution is a spawn site too (#16's actual incident shape) ==============================================
+
+#[skuld::test]
+fn cmdsub_child_does_not_reach_host_fd(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // The shape that corrupted the corpus harness's database, verbatim:
+    //   bash -c 'exec 3>tgt; x=$(sh -c "echo REDIR >&3")' 3>probe
+    //     -> tgt holds "REDIR", probe empty.
+    // `execute_command_substitution` built its child's fd table from nothing but
+    // a stdout pipe, so the shell's `exec 3>tgt` was invisible to it and the
+    // write went to the host's descriptor instead.
+    let probe = HostFd::new(dir.join("cmdsub-probe.txt"));
+    let target = dir.join("cmdsub-target.txt");
+
+    let script = format!(
+        "exec {fd}>{t}; x=$({wf} {fd} REDIR)",
+        fd = probe.fd,
+        t = shell_path(&target),
+        wf = tool(tools, "writefd")
+    );
+    exec!(&script);
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "REDIR\n");
+    assert_eq!(probe.contents(), "", "the host's descriptor must not receive the write");
+}
+
+#[skuld::test]
+fn closed_fd_not_inherited_by_cmdsub(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'exec 3>&-; x=$(sh -c "echo LEAK >&3")' 3>probe -> probe empty.
+    let probe = HostFd::new(dir.join("cmdsub-closed.txt"));
+
+    let script = format!(
+        "exec {fd}>&-; x=$({wf} {fd} LEAK); echo \"x=[$x]\"",
+        fd = probe.fd,
+        wf = tool(tools, "writefd")
+    );
+    let r = exec!(&script);
+    r.stdout();
+    r.stderr();
+    assert_eq!(
+        probe.contents(),
+        "",
+        "command substitution must not inherit a closed descriptor"
+    );
+}
+
+// Closing by number, not by the direction of the operator =============================================================
+
+#[skuld::test]
+fn close_clears_the_slot_for_its_number_not_its_direction(#[fixture(temp_dir)] dir: &Path) {
+    // `0>&-` closes descriptor 0 even though `>` reads as an output operator:
+    //   bash -c 'exec 0<src 0>&-; read x; echo "rc=$? x=[$x]"'
+    //     -> "read: 0: read error: Bad file descriptor", rc=1, x empty.
+    // Routing by operator direction left stdin assigned, so the read succeeded.
+    let src = dir.join("close-direction.txt");
+    std::fs::write(&src, "DATA\n").unwrap();
+
+    let script = format!("exec 0<{s} 0>&-; read x; echo \"rc=$? x=[$x]\"", s = shell_path(&src));
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1 x=[]\n", "0>&- must close descriptor 0");
+    r.stderr();
+}
+
+#[skuld::test]
+fn closed_stdin_not_inherited_by_child(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // `exec 0<&-` must reach children as a genuine close:
+    //   printf X | bash -c 'exec 0<&-; cat'  ->  "cat: stdin: Bad file descriptor"
+    // `adopt_redirects` substituted /dev/null for fds 0-2 without recording the
+    // close, so `io.closed_fds()` was empty for them and the child inherited the
+    // host's stdin.
+    let src = dir.join("closed-stdin.txt");
+    std::fs::write(&src, "HOSTDATA\n").unwrap();
+    let cat = tool(tools, "cat");
+
+    let script = format!("exec 0<{s}; exec 0<&-; {cat}", s = shell_path(&src));
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "", "a closed stdin must not reach the child");
+    r.stderr();
+    r.status();
+}
+
+// Malformed move targets ==============================================================================================
+
+#[skuld::test]
+fn move_target_rejects_non_digits() {
+    // `exec 3>&-3-` must not parse as a move from descriptor -3. bash rejects
+    // the word outright ("exec: 3-: not found"); thaum reports a bad redirect.
+    // Either way the command fails and the script continues — what must not
+    // happen is a negative descriptor reaching the closed set and then `dup2`.
+    let r = exec!("exec 3>&-3-; echo alive");
+    assert_eq!(
+        r.stdout(),
+        "alive\n",
+        "a malformed move target must not abort the script"
+    );
+    r.stderr();
+    r.status();
 }
 
 // Numeric-move redirections `N>&M-` / `N<&M-` (#17's audit) ===========================================================

--- a/tests/exec/descriptors.rs
+++ b/tests/exec/descriptors.rs
@@ -1,0 +1,582 @@
+//! Descriptor-state tests: what `exec` opens, what `>&-` closes, and what a
+//! child is allowed to inherit.
+//!
+//! These tests are about the boundary between the shell's fd table and the
+//! *host process's* fd table. thaum is embeddable, so a descriptor the host
+//! opened must never receive a write the script directed elsewhere — and a
+//! descriptor the script closed must not reappear through the host's table.
+//!
+//! Every expected value here was derived by running the equivalent script
+//! under GNU bash 5.3, never by running thaum and recording what it did.
+//!
+//! **A descriptor under test is never obtained with `dup2` onto a fixed
+//! number.** `HostFd` takes whatever number `into_raw_fd` hands back, which the
+//! OS guarantees is unused. The test harness holds open descriptors of its own
+//! — including skuld's cross-process coordination database — and stamping on a
+//! literal fd 3 would corrupt them.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+
+use crate::*;
+
+/// A real file, open on a real descriptor of *this* process, which the shell
+/// under test never opened — the embedder's descriptor.
+///
+/// The number comes from `into_raw_fd`, so it is exclusively ours and no
+/// concurrent test can be holding it.
+struct HostFd {
+    fd: i32,
+    path: PathBuf,
+}
+
+impl HostFd {
+    fn new(path: PathBuf) -> Self {
+        use std::os::fd::{AsRawFd, IntoRawFd};
+        let file = std::fs::File::create(&path).expect("create host fd probe file");
+
+        // Rust opens files `O_CLOEXEC`, and `try_clone` preserves that. A
+        // descriptor an embedder hands us is not close-on-exec — the one in the
+        // original incident arrived through a shell redirect — so duplicate it
+        // with a plain `dup(2)`, which POSIX defines as clearing FD_CLOEXEC.
+        // Without this the probe vanishes at `exec` and every "the child could
+        // not reach it" assertion passes for the wrong reason.
+        let inheritable =
+            thaum::exec::buffered_file::dup_process_fd(file.as_raw_fd()).expect("dup host fd probe descriptor");
+        drop(file);
+
+        let fd = inheritable.into_raw_fd();
+        HostFd { fd, path }
+    }
+
+    /// What the host's file actually received. Empty means the escape is closed.
+    fn contents(&self) -> String {
+        std::fs::read_to_string(&self.path).expect("read host fd probe file")
+    }
+}
+
+impl Drop for HostFd {
+    fn drop(&mut self) {
+        use std::os::fd::FromRawFd;
+        // SAFETY: `self.fd` came from `into_raw_fd` and has not been closed.
+        drop(unsafe { std::fs::File::from_raw_fd(self.fd) });
+    }
+}
+
+fn shell_path(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// Absolute path to a `test_tools` binary, for use inside a script.
+///
+/// Deliberately **not** invoked through `PATH`: thaum's external-command lookup
+/// does not consult the shell's `PATH` variable (issue #15), so a bare name
+/// would silently resolve against the process environment — or not at all.
+fn tool(tools: &Path, name: &str) -> String {
+    shell_path(&tools.join(name))
+}
+
+// Control: inherited descriptors are not the bug ======================================================================
+
+#[skuld::test]
+fn inherited_fd_is_writable_by_child(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // A child writing to a descriptor it legitimately inherited is ordinary
+    // POSIX, and bash does exactly the same:
+    //   bash -c 'sh -c "echo inherited >&3"; echo rc=$?' 3>probe
+    //     -> rc=0, probe contains "inherited"
+    // This must keep working. It is the behaviour issues #16 and #17 both
+    // single out as *not* the defect.
+    let probe = HostFd::new(dir.join("inherited.txt"));
+
+    let script = format!("{} {} inherited; echo rc=$?", tool(tools, "writefd"), probe.fd);
+    let r = exec!(&script);
+    assert_eq!(
+        r.stdout(),
+        "rc=0\n",
+        "child should be able to write to an inherited descriptor"
+    );
+    assert_eq!(probe.contents(), "inherited\n");
+}
+
+#[skuld::test]
+fn inherited_fd_is_writable_by_shell(#[fixture(temp_dir)] dir: &Path) {
+    // The shell's own redirection to an inherited descriptor also works in
+    // bash: `bash -c 'echo self >&3' 3>probe` puts "self" in probe.
+    let probe = HostFd::new(dir.join("shell-inherited.txt"));
+
+    let script = format!("echo self >&{}", probe.fd);
+    exec!(&script);
+    assert_eq!(probe.contents(), "self\n");
+}
+
+#[skuld::test]
+fn inherited_fd_survives_unrelated_close(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // Closing one descriptor must not disturb another.
+    let probe = HostFd::new(dir.join("survives.txt"));
+    let other = HostFd::new(dir.join("other.txt"));
+
+    let script = format!(
+        "exec {}>&-; {} {} inherited",
+        other.fd,
+        tool(tools, "writefd"),
+        probe.fd
+    );
+    exec!(&script);
+    assert_eq!(probe.contents(), "inherited\n");
+    assert_eq!(other.contents(), "", "the closed descriptor must not receive anything");
+}
+
+#[skuld::test]
+fn reopened_fd_is_inheritable_again(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'exec 3>&-; exec 3>r1; echo re >&3' leaves "re" in r1: a close
+    // is not permanent, and reopening the number restores it for children too.
+    let probe = HostFd::new(dir.join("reopened.txt"));
+    let target = dir.join("reopened-target.txt");
+
+    let script = format!(
+        "exec {fd}>&-; exec {fd}>{target}; {wf} {fd} re",
+        fd = probe.fd,
+        target = shell_path(&target),
+        wf = tool(tools, "writefd")
+    );
+    exec!(&script);
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "re\n");
+    assert_eq!(probe.contents(), "", "the host's file must not receive the write");
+}
+
+// `exec` must apply the redirections that follow its options (#16) ====================================================
+
+#[skuld::test]
+fn exec_dashdash_applies_redirections(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec -- 3>&1; echo hi 1>&3' 3>probe
+    //   -> "hi" on stdout, probe empty.
+    // thaum accepted the `--`, dropped `3>&1`, and the write landed in the
+    // host's file. This is the case that overwrote a live SQLite database.
+    let probe = HostFd::new(dir.join("dashdash.txt"));
+
+    let script = format!("exec -- {fd}>&1; echo hi 1>&{fd}", fd = probe.fd);
+    let r = exec!(&script);
+    assert_eq!(
+        r.stdout(),
+        "hi\n",
+        "`exec --` must apply the redirections that follow it"
+    );
+    assert_eq!(probe.contents(), "", "the host's descriptor must not receive the write");
+}
+
+#[skuld::test]
+fn exec_dash_a_with_no_command_applies_redirections(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec -a foo 3>&1; echo hi >&3; echo rc=$?' 3>probe
+    //   -> "hi", "rc=0", probe empty.
+    // Same defect reached through a different option.
+    let probe = HostFd::new(dir.join("dash-a.txt"));
+
+    let script = format!("exec -a foo {fd}>&1; echo hi >&{fd}; echo rc=$?", fd = probe.fd);
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "hi\nrc=0\n");
+    assert_eq!(probe.contents(), "");
+}
+
+#[skuld::test]
+fn exec_dash_a_dashdash_with_no_command_applies_redirections(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec -a foo -- 3>&1; echo hi >&3' 3>probe -> "hi", probe empty.
+    let probe = HostFd::new(dir.join("dash-a-dashdash.txt"));
+
+    let script = format!("exec -a foo -- {fd}>&1; echo hi >&{fd}", fd = probe.fd);
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "hi\n");
+    assert_eq!(probe.contents(), "");
+}
+
+#[skuld::test]
+fn exec_dashdash_alone_is_a_noop() {
+    // bash -c 'exec --; echo alive rc=$?' -> "alive rc=0". No command word, no
+    // redirections: nothing to do, and the shell survives.
+    let r = exec!("exec --; echo alive rc=$?");
+    assert_eq!(r.stdout(), "alive rc=0\n");
+}
+
+#[skuld::test]
+fn exec_dashdash_ends_option_parsing() {
+    // bash -c 'exec -- -a 3>&1' -> "exec: -a: not found".
+    // `--` must stop option parsing, so `-a` is a command name, not the
+    // argv0-override flag. Getting this wrong would silently swallow the word.
+    let r = exec!("exec -- -a", mode = ExecMode::Subprocess);
+    assert_ne!(r.status(), 0, "`-a` after `--` is a command name, not a flag");
+    assert!(
+        r.stderr().contains("-a"),
+        "expected `-a` to be reported as a command, got: {}",
+        r.stderr()
+    );
+    r.stdout();
+}
+
+#[skuld::test]
+fn exec_invalid_option_still_applies_redirections(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec -q 3>&1; echo after >&3; echo rc=$?' 3>probe
+    //   -> stderr "exec: -q: invalid option" plus usage, "after" on stdout,
+    //      "rc=0" (the rc of `echo`, not of `exec`), probe empty.
+    // bash makes an `exec` redirection permanent even when the builtin then
+    // rejects an option, which is also the fail-safe direction: the write goes
+    // where the script asked rather than to the host.
+    let probe = HostFd::new(dir.join("invalid-option.txt"));
+
+    let script = format!("exec -q {fd}>&1; echo after >&{fd}; echo rc=$?", fd = probe.fd);
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "after\nrc=0\n");
+    assert!(
+        r.stderr().contains("invalid option"),
+        "expected an invalid-option diagnostic, got: {}",
+        r.stderr()
+    );
+    assert_eq!(probe.contents(), "");
+}
+
+// `>&-` must actually close, for the shell (#17) ======================================================================
+
+#[skuld::test]
+fn closed_fd_is_unreachable_from_shell(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 3>&-; echo self >&3; echo rc=$?; echo alive' 3>probe
+    //   -> "Bad file descriptor" on stderr, rc=1, "alive", probe empty.
+    // The failure is per-command: the script keeps running.
+    let probe = HostFd::new(dir.join("unreachable.txt"));
+
+    let script = format!("exec {fd}>&-; echo self >&{fd}; echo rc=$?; echo alive", fd = probe.fd);
+    let r = exec!(&script);
+    assert_eq!(
+        r.stdout(),
+        "rc=1\nalive\n",
+        "a closed descriptor must fail the command, not the script"
+    );
+    assert!(
+        r.stderr().contains("bad file descriptor"),
+        "expected a bad-descriptor diagnostic, got: {}",
+        r.stderr()
+    );
+    assert_eq!(
+        probe.contents(),
+        "",
+        "the host's descriptor must not be reachable after close"
+    );
+}
+
+#[skuld::test]
+fn closed_fd_is_unreachable_within_same_redirect_list(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 3>f.txt; { echo x >&4; } 3>&- 4>&3; echo done'
+    //   -> "3: Bad file descriptor" on stderr, "done" on stdout, f.txt empty.
+    // A close earlier in the same redirect list must make the number
+    // unresolvable to a later `>&N` in that list.
+    let target = dir.join("same-list.txt");
+
+    let script = format!(
+        "exec 3>{t}; {{ echo x >&4; }} 3>&- 4>&3; echo done",
+        t = shell_path(&target)
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "done\n");
+    assert!(
+        r.stderr().contains("bad file descriptor"),
+        "expected a bad-descriptor diagnostic, got: {}",
+        r.stderr()
+    );
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "");
+    let _ = dir;
+}
+
+// Within one redirect list, the last word about a descriptor wins =====================================================
+
+#[skuld::test]
+fn redirect_list_reopen_after_close_wins(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 3>f; echo first >&3; { echo second >&3; } 3>&- 3>g'
+    //   -> f holds "first", g holds "second", rc 0.
+    let f = dir.join("reopen-f.txt");
+    let g = dir.join("reopen-g.txt");
+
+    let script = format!(
+        "exec 3>{f}; echo first >&3; {{ echo second >&3; }} 3>&- 3>{g}",
+        f = shell_path(&f),
+        g = shell_path(&g)
+    );
+    exec!(&script);
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "first\n");
+    assert_eq!(
+        std::fs::read_to_string(&g).unwrap(),
+        "second\n",
+        "the later redirect must win"
+    );
+}
+
+#[skuld::test]
+fn redirect_list_close_after_reopen_wins(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 3>f; { echo x >&3; } 3>g 3>&-; echo done'
+    //   -> "3: Bad file descriptor" on stderr, "done" on stdout, both files
+    //      empty (g is still created and truncated), rc 0.
+    let f = dir.join("close-f.txt");
+    let g = dir.join("close-g.txt");
+
+    let script = format!(
+        "exec 3>{f}; {{ echo x >&3; }} 3>{g} 3>&-; echo done",
+        f = shell_path(&f),
+        g = shell_path(&g)
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "done\n");
+    assert!(
+        r.stderr().contains("bad file descriptor"),
+        "expected a bad-descriptor diagnostic, got: {}",
+        r.stderr()
+    );
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "");
+    assert_eq!(std::fs::read_to_string(&g).unwrap(), "", "the later close must win");
+}
+
+// `>&-` must actually close, for children (#17) =======================================================================
+
+#[skuld::test]
+fn closed_fd_not_inherited_by_external(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'exec 3>&-; sh -c "echo closed >&3"; echo rc=$?' 3>probe
+    //   -> "sh: 3: Bad file descriptor", rc=1, probe empty.
+    let probe = HostFd::new(dir.join("external.txt"));
+
+    let script = format!(
+        "exec {fd}>&-; {wf} {fd} escaped; echo rc=$?",
+        fd = probe.fd,
+        wf = tool(tools, "writefd")
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1\n", "the child must fail on the closed descriptor");
+    r.stderr();
+    assert_eq!(
+        probe.contents(),
+        "",
+        "the host's descriptor must not be inherited after close"
+    );
+}
+
+#[skuld::test]
+fn closed_fd_not_inherited_per_command(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'sh -c "echo x >&3" 3>&-; echo rc=$?' 3>probe
+    //   -> "sh: 3: Bad file descriptor", rc=1, probe empty.
+    // A per-command close, with no `exec` involved.
+    let probe = HostFd::new(dir.join("per-command.txt"));
+
+    let script = format!(
+        "{wf} {fd} escaped {fd}>&-; echo rc=$?",
+        fd = probe.fd,
+        wf = tool(tools, "writefd")
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1\n");
+    r.stderr();
+    assert_eq!(probe.contents(), "");
+}
+
+#[skuld::test]
+fn closed_fd_not_inherited_by_pipeline(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'exec 3>&-; sh -c "echo x >&3" | cat' 3>probe -> probe empty.
+    let probe = HostFd::new(dir.join("pipeline.txt"));
+
+    let script = format!(
+        "exec {fd}>&-; {wf} {fd} escaped | {ct}",
+        fd = probe.fd,
+        wf = tool(tools, "writefd"),
+        ct = tool(tools, "cat")
+    );
+    let r = exec!(&script);
+    r.stdout();
+    r.stderr();
+    r.status();
+    assert_eq!(
+        probe.contents(),
+        "",
+        "a pipeline stage must not inherit a closed descriptor"
+    );
+}
+
+#[skuld::test]
+fn closed_fd_not_inherited_by_subshell(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // bash -c 'exec 3>&-; (sh -c "echo x >&3")' 3>probe -> probe empty.
+    let probe = HostFd::new(dir.join("subshell.txt"));
+
+    let script = format!(
+        "exec {fd}>&-; ({wf} {fd} escaped)",
+        fd = probe.fd,
+        wf = tool(tools, "writefd")
+    );
+    let r = exec!(&script);
+    r.stdout();
+    r.stderr();
+    r.status();
+    assert_eq!(probe.contents(), "", "a subshell must not inherit a closed descriptor");
+}
+
+#[skuld::test]
+fn closed_input_fd_not_inherited(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // The `<&-` spelling shares the path: bash -c 'exec 3<&-; sh -c "echo x >&3"'
+    // 3>probe leaves probe empty and reports "Bad file descriptor".
+    let probe = HostFd::new(dir.join("input-close.txt"));
+
+    let script = format!(
+        "exec {fd}<&-; {wf} {fd} escaped; echo rc=$?",
+        fd = probe.fd,
+        wf = tool(tools, "writefd")
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1\n");
+    r.stderr();
+    assert_eq!(probe.contents(), "");
+}
+
+#[skuld::test]
+fn close_of_unopened_fd_does_not_break_spawn(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // Closing a number the shell never opened must not make the next spawn
+    // fail. On macOS a bare `posix_spawn_file_actions_addclose` against a
+    // descriptor that is not open fails the whole spawn with EBADF, so this
+    // pins the dup2-then-close construction. bash agrees the close is a no-op:
+    //   bash -c 'exec 21>&-; echo ok'  ->  "ok"
+    // The command must be an *external* one, since the risk is in the spawn.
+    let marker = dir.join("spawn-marker.txt");
+    std::fs::write(&marker, "ok\n").unwrap();
+
+    let script = format!("exec 21>&-; {ct} {t}", ct = tool(tools, "cat"), t = shell_path(&marker));
+    let r = exec!(&script);
+    assert_eq!(
+        r.stdout(),
+        "ok\n",
+        "a close of an unopened number must not break the next spawn"
+    );
+}
+
+// Closed standard descriptors are closed in the child too (#41's child half) ==========================================
+
+#[skuld::test]
+fn closed_stdout_not_inherited_by_child(#[fixture(test_tools)] tools: &Path) {
+    // bash -c 'sh -c "echo LEAKED" 1>&-' prints nothing: the child's stdout is
+    // gone. thaum handed the child a pipe wired to the host's stdout instead,
+    // so "LEAKED" came out — a write escape on descriptor 1.
+    //
+    // Only the absence of the leak is asserted, not the child's exit status.
+    // The Rust runtime reopens /dev/null over any of fds 0-2 it finds closed at
+    // startup, so a Rust observer cannot report EBADF on descriptor 1 and would
+    // exit 0 either way. A C observer does see it: through the real binary,
+    // `thaum exec -c 'sh -c "echo LEAKED" 1>&-; echo rc=$?'` gives
+    // "echo: write error: Bad file descriptor" and rc=1, matching bash.
+    let script = format!("{wf} 1 LEAKED 1>&-; echo done", wf = tool(tools, "writefd"));
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "done\n", "a closed stdout must not reach the host");
+    r.stderr();
+}
+
+// Numeric-move redirections `N>&M-` / `N<&M-` (#17's audit) ===========================================================
+
+#[skuld::test]
+fn move_output_fd_closes_source(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 5>f; echo hello5 >&5; exec 6>&5-; echo world5 >&5;
+    //          echo world6 >&6; exec 6>&-; cat f'
+    //   -> stderr "5: Bad file descriptor"; f holds "hello5\nworld6".
+    // The move duplicates 5 onto 6 and then closes 5.
+    let f = dir.join("move-out.txt");
+
+    let script = format!(
+        "exec 5>{f}; echo hello5 >&5; exec 6>&5-; echo world5 >&5; echo world6 >&6; exec 6>&-",
+        f = shell_path(&f)
+    );
+    let r = exec!(&script);
+    assert!(
+        r.stderr().contains("bad file descriptor"),
+        "the source descriptor must be closed by the move, got stderr: {}",
+        r.stderr()
+    );
+    assert_eq!(std::fs::read_to_string(&f).unwrap(), "hello5\nworld6\n");
+}
+
+#[skuld::test]
+fn move_output_fd_source_becomes_unusable(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 3>out; exec 4>&3-; echo moved >&4; echo after >&3; echo rc=$?'
+    //   -> out holds "moved"; stderr "3: Bad file descriptor"; rc=1.
+    // The destination takes over the file and the source is genuinely closed.
+    let out = dir.join("move-source.txt");
+
+    let script = format!(
+        "exec 3>{out}; exec 4>&3-; echo moved >&4; echo after >&3; echo rc=$?",
+        out = shell_path(&out)
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1\n", "writing to the moved-from descriptor must fail");
+    assert!(
+        r.stderr().contains("bad file descriptor"),
+        "expected a bad-descriptor diagnostic, got: {}",
+        r.stderr()
+    );
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "moved\n");
+}
+
+#[skuld::test]
+fn move_input_fd_closes_source(#[fixture(temp_dir)] dir: &Path) {
+    // bash -c 'exec 4<&3-; cat <&4' with 3 on a file reads the file, and
+    // descriptor 3 is then closed:
+    //   bash -c 'exec 4<&0-; cat <&4; sh -c "cat <&0"' < src
+    //     -> "DATA", then "cat: stdin: Bad file descriptor".
+    let src = dir.join("move-in.txt");
+    std::fs::write(&src, "DATA\n").unwrap();
+
+    let script = format!(
+        "exec 3<{src}; exec 4<&3-; read line <&4; echo \"got=$line\"; read x <&3; echo rc=$?",
+        src = shell_path(&src)
+    );
+    let r = exec!(&script);
+    assert_eq!(
+        r.stdout(),
+        "got=DATA\nrc=1\n",
+        "the move must transfer the read and close the source"
+    );
+    r.stderr();
+}
+
+#[skuld::test]
+fn move_fd_does_not_leak_to_host(#[fixture(temp_dir)] dir: &Path) {
+    // The move form failed with "ambiguous redirect" and applied nothing, so
+    // the host's descriptor stayed live and received the write — the same
+    // escape as #16 by another route.
+    //   bash -c 'exec 4>tgt; exec N>&4-; echo moved >&N; echo after >&4; echo rc=$?' N>probe
+    //     -> tgt holds "moved", probe empty, stderr "4: Bad file descriptor",
+    //        rc=1. Measured identically for N = 3, 5, 9, 12 and 21, so the
+    //        arbitrary number `HostFd` hands out is safe here.
+    let probe = HostFd::new(dir.join("move-leak.txt"));
+    // The scratch number the shell opens must not be a literal. `HostFd` takes
+    // whatever the OS hands out, which can be any low number, so a literal `4`
+    // here would collide with `probe.fd` on the runs where the OS picked 4.
+    // Reserving a second descriptor makes the two numbers distinct by
+    // construction rather than by luck.
+    let scratch = HostFd::new(dir.join("move-leak-scratch.txt"));
+    let target = dir.join("move-leak-target.txt");
+
+    let script = format!(
+        "exec {s}>{t}; exec {fd}>&{s}-; echo moved >&{fd}; echo after >&{s}; echo rc=$?",
+        s = scratch.fd,
+        t = shell_path(&target),
+        fd = probe.fd
+    );
+    let r = exec!(&script);
+    assert_eq!(r.stdout(), "rc=1\n");
+    r.stderr();
+    assert_eq!(
+        std::fs::read_to_string(&target).unwrap(),
+        "moved\n",
+        "the move must redirect to the source's file"
+    );
+    assert_eq!(probe.contents(), "", "the host's descriptor must not receive the write");
+}
+
+// Subprocess parity ===================================================================================================
+
+#[skuld::test]
+fn exec_dashdash_applies_redirections_in_subprocess(#[fixture(temp_dir)] dir: &Path) {
+    // The same case through a real `thaum` process, which is how issue #16
+    // reproduces it. Guards against the fix living only on the in-process path.
+    let target = dir.join("subprocess-dashdash.txt");
+    let script = format!("exec -- 3>{t}; echo hi 1>&3", t = shell_path(&target));
+    exec!(&script, mode = ExecMode::Subprocess);
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "hi\n");
+}

--- a/tests/exec/descriptors.rs
+++ b/tests/exec/descriptors.rs
@@ -448,38 +448,60 @@ fn close_of_unopened_fd_does_not_break_spawn(#[fixture(temp_dir)] dir: &Path, #[
     // It must not break the *spawn* that follows, so the command has to be an
     // external one.
     //
-    // Swept rather than pinned to one number. The first version of this test
-    // hardcoded 21 and passed while fd 12 failed: which numbers collide depends
-    // on where /dev/null and the capture pipes happen to land, so a single
-    // number tests almost nothing.
+    // Two properties this test learned the hard way:
+    //
+    // * Swept, not pinned. The first version hardcoded fd 21 and passed while
+    //   fd 12 failed — which numbers collide depends on where /dev/null and the
+    //   capture pipes land.
+    // * Run as a *subprocess*. In-process it cannot fail: the test binary holds
+    //   ~10 descriptors open, so the internal /dev/null lands clear of every
+    //   number under test and the collision never happens. A real `thaum`
+    //   process starts with a near-empty fd table, which is the shape that
+    //   breaks.
+    //
+    // This is a breadth check and it is *probabilistic*: with the fix reverted
+    // it fails about one run in three. The reliable guard for the file-action
+    // collision is `closing_several_fds_does_not_break_spawn`, which fails
+    // every time. Do not treat this one as the regression test for it.
     let marker = dir.join("spawn-marker.txt");
     std::fs::write(&marker, "ok\n").unwrap();
     let cat = tool(tools, "cat");
 
-    for fd in 3..=24 {
+    // Repeated per number: the collision depends on HashMap iteration order, so
+    // one attempt per fd caught it only about a third of the time.
+    for fd in 3..=20 {
         let script = format!("exec {fd}>&-; {cat} {t}", t = shell_path(&marker));
-        let r = exec!(&script);
-        assert_eq!(r.stdout(), "ok\n", "closing fd {fd} broke the following spawn");
+        for attempt in 0..3 {
+            let r = exec!(&script, mode = ExecMode::Subprocess);
+            assert_eq!(
+                r.stdout(),
+                "ok\n",
+                "closing fd {fd} broke the following spawn (attempt {attempt})"
+            );
+        }
     }
 }
 
 #[skuld::test]
 fn closing_several_fds_does_not_break_spawn(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
-    // Two or more closes in one command is the shape that exposed the
-    // file-action collision: the shared /dev/null source could itself sit on a
-    // number that another entry closed, and `posix_spawn` then failed the whole
-    // spawn with EBADF. `bash -c 'exec 6>&- 7>&-; echo ok'` prints "ok".
+    // Several closes in one command is the shape that exposed the file-action
+    // collision: the shared /dev/null source could itself sit on a number
+    // another entry closed, and `posix_spawn` then failed the whole spawn with
+    // EBADF. `bash -c 'exec 6>&- 7>&-; echo ok'` prints "ok".
     //
-    // Repeated because the failure was nondeterministic — `cmd.fds` is a
-    // HashMap and its iteration order varies per process, so a single
-    // invocation missed it most of the time.
+    // Subprocess mode and repeated, because the failure is nondeterministic —
+    // `cmd.fds` is a HashMap and its iteration order varies per process.
+    //
+    // This is the primary guard for the collision: with `relocate_clear_of`
+    // reverted it fails on every run (verified 3/3), where the single-close
+    // sweep above catches it only about a third of the time.
     let marker = dir.join("multi-marker.txt");
     std::fs::write(&marker, "ok\n").unwrap();
     let cat = tool(tools, "cat");
     let script = format!("exec 5>&- 6>&- 7>&- 8>&-; {cat} {t}", t = shell_path(&marker));
 
-    for attempt in 0..25 {
-        let r = exec!(&script);
+    for attempt in 0..20 {
+        let r = exec!(&script, mode = ExecMode::Subprocess);
         assert_eq!(r.stdout(), "ok\n", "multi-close broke the spawn on attempt {attempt}");
     }
 }
@@ -493,17 +515,78 @@ fn closing_several_fds_does_not_break_pipeline_or_subshell(
     let marker = dir.join("multi-ps-marker.txt");
     std::fs::write(&marker, "ok\n").unwrap();
     let cat = tool(tools, "cat");
+    let t = shell_path(&marker);
 
-    for attempt in 0..15 {
-        let r = exec!(&format!(
-            "exec 5>&- 6>&- 7>&-; {cat} {t} | {cat}",
-            t = shell_path(&marker)
-        ));
+    for attempt in 0..10 {
+        let r = exec!(
+            &format!("exec 5>&- 6>&- 7>&-; {cat} {t} | {cat}"),
+            mode = ExecMode::Subprocess
+        );
         assert_eq!(r.stdout(), "ok\n", "pipeline broke on attempt {attempt}");
 
-        let r = exec!(&format!("exec 5>&- 6>&- 7>&-; ({cat} {t})", t = shell_path(&marker)));
+        let r = exec!(
+            &format!("exec 5>&- 6>&- 7>&-; ({cat} {t})"),
+            mode = ExecMode::Subprocess
+        );
         assert_eq!(r.stdout(), "ok\n", "subshell broke on attempt {attempt}");
     }
+}
+
+#[skuld::test]
+fn close_of_absurd_fd_number_is_a_noop(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
+    // A descriptor number above RLIMIT_NOFILE cannot be open, so closing it is
+    // a no-op — `bash -c 'exec 2000000>&-; echo ok'` prints "ok". Relocating a
+    // spawn source above such a number instead pushed past the limit and
+    // `posix_spawn` rejected it with EINVAL, losing the command entirely.
+    // Swept across the boundary. macOS rejects fds from 10240 upward from
+    // `posix_spawn_file_actions_adddup2`, and that bound is not reachable via
+    // `sysconf(_SC_OPEN_MAX)` or `getdtablesize()` — so this pins the behaviour
+    // either side of it rather than the constant. bash prints "ok" for all.
+    let marker = dir.join("absurd-marker.txt");
+    std::fs::write(&marker, "ok\n").unwrap();
+    let cat = tool(tools, "cat");
+
+    for fd in [10239, 10240, 10241, 100_000, 1_048_575, 2_000_000] {
+        let script = format!("exec {fd}>&-; {cat} {t}", t = shell_path(&marker));
+        let r = exec!(&script, mode = ExecMode::Subprocess);
+        assert_eq!(
+            r.stdout(),
+            "ok\n",
+            "closing fd {fd} must be a no-op, not a spawn failure"
+        );
+    }
+}
+
+// A close must not displace the runtime's own plumbing ================================================================
+
+#[skuld::test]
+fn closed_stdin_does_not_break_subshells() {
+    // `exec 0<&-` is the standard way to harden a script against stdin, and in
+    // bash the subshells that follow still run:
+    //   bash -c 'exec 0<&-; (echo hi); echo rc=$?'  ->  "hi", "rc=0"
+    // thaum ships the subshell's AST to a `thaum exec-ast` child over fd 0, so
+    // closing descriptor 0 in the child destroyed the transport and every
+    // subshell silently failed with "invalid JSON payload".
+    let r = exec!("exec 0<&-; (echo hi); echo rc=$?");
+    assert_eq!(r.stdout(), "hi\nrc=0\n", "a closed stdin must not disable subshells");
+    r.stderr();
+}
+
+#[skuld::test]
+fn closed_stdin_does_not_break_subshells_bare_form() {
+    // `exec <&-` is the same operation spelled without the number.
+    let r = exec!("exec <&-; (echo hi); echo rc=$?");
+    assert_eq!(r.stdout(), "hi\nrc=0\n");
+    r.stderr();
+}
+
+#[skuld::test]
+fn closed_stdout_does_not_break_subshell_capture() {
+    // Closing stdout must not cost the subshell its capture pipe either: bash
+    // runs the subshell and discards its output, rather than losing the child.
+    let r = exec!("exec 1>&-; (echo hi); echo done >&2");
+    assert_eq!(r.stdout(), "", "a closed stdout discards output");
+    assert_eq!(r.stderr(), "done\n", "the subshell must still run");
 }
 
 // Closed standard descriptors are closed in the child too (#41's child half) ==========================================

--- a/tests/exec/descriptors.rs
+++ b/tests/exec/descriptors.rs
@@ -77,6 +77,40 @@ fn tool(tools: &Path, name: &str) -> String {
     shell_path(&tools.join(name))
 }
 
+/// Run `script` in a real `thaum` process with `stdin_data` on descriptor 0.
+///
+/// The `exec!` harness cannot express this. `ExecMode::InProcess` gives the
+/// executor a `CapturedIo` pipe that carries no data, and `ExecMode::Subprocess`
+/// goes through `Command::output()`, which hands the child a null stdin. Either
+/// way an assertion about descriptor 0 holds whether or not the code under test
+/// works — which is exactly how the first version of
+/// `closed_stdin_not_inherited_by_child` came to pass against a reverted fix.
+fn run_with_stdin(script: &str, stdin_data: &[u8]) -> (String, String) {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new(crate::thaum_exe())
+        .args(["exec", "-c", script])
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn thaum");
+    child
+        .stdin
+        .take()
+        .expect("stdin pipe")
+        .write_all(stdin_data)
+        .expect("write stdin");
+    let out = child.wait_with_output().expect("wait for thaum");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
 // Control: inherited descriptors are not the bug ======================================================================
 
 #[skuld::test]
@@ -675,21 +709,44 @@ fn close_clears_the_slot_for_its_number_not_its_direction(#[fixture(temp_dir)] d
 }
 
 #[skuld::test]
-fn closed_stdin_not_inherited_by_child(#[fixture(temp_dir)] dir: &Path, #[fixture(test_tools)] tools: &Path) {
-    // `exec 0<&-` must reach children as a genuine close:
-    //   printf X | bash -c 'exec 0<&-; cat'  ->  "cat: stdin: Bad file descriptor"
-    // `adopt_redirects` substituted /dev/null for fds 0-2 without recording the
-    // close, so `io.closed_fds()` was empty for them and the child inherited the
-    // host's stdin.
-    let src = dir.join("closed-stdin.txt");
-    std::fs::write(&src, "HOSTDATA\n").unwrap();
-    let cat = tool(tools, "cat");
+fn closed_stdin_not_inherited_by_child() {
+    // `exec 0<&-` must reach children as a genuine close. The descriptor being
+    // closed has to be one the child could otherwise *read*, so the host's real
+    // stdin carries data here:
+    //   printf HOST | bash -c 'exec 0<&-; cat'  ->  "cat: stdin: Bad file descriptor"
+    // Before the fix the child read "HOST": `adopt_redirects` substituted
+    // /dev/null for fds 0-2 without recording the close, so `io.closed_fds()`
+    // was empty for them.
+    //
+    // An earlier version of this test wrote `exec 0<src; exec 0<&-; cat` and
+    // asserted empty stdout. That could not fail: `exec 0<file` does not reach
+    // children at all (issue #47), so the child never had the file on
+    // descriptor 0 under any version, and the harness's stdin was empty anyway.
+    // `/bin/cat` rather than the Rust `test-cat`: the Rust runtime reopens
+    // /dev/null over any of fds 0-2 it finds closed at startup, so a Rust
+    // observer reads EOF and reports nothing whether the descriptor was closed
+    // or merely empty. A C observer distinguishes the two.
+    //
+    // Verified by mutation: with the closed marker removed from
+    // `adopt_redirects`, this reads "HOST"; with it, `cat` reports
+    // "stdin: Bad file descriptor".
+    let (stdout, stderr) = run_with_stdin("exec 0<&-; /bin/cat", b"HOST\n");
+    assert_eq!(
+        stdout, "",
+        "a closed stdin must not reach the child; it read the host's"
+    );
+    assert!(
+        stderr.contains("Bad file descriptor"),
+        "the child should report the closed descriptor, got: {stderr}"
+    );
+}
 
-    let script = format!("exec 0<{s}; exec 0<&-; {cat}", s = shell_path(&src));
-    let r = exec!(&script);
-    assert_eq!(r.stdout(), "", "a closed stdin must not reach the child");
-    r.stderr();
-    r.status();
+#[skuld::test]
+fn inherited_stdin_still_reaches_child() {
+    // The control for the test above: with no close, the child reads the host's
+    // stdin, exactly as bash does. If this fails, the fix has over-reached.
+    let (stdout, _stderr) = run_with_stdin("/bin/cat", b"HOST\n");
+    assert_eq!(stdout, "HOST\n", "an un-closed stdin must still reach the child");
 }
 
 // Malformed move targets ==============================================================================================


### PR DESCRIPTION
Closes #16. Closes #17.

`exec --` dropped the redirections that followed it, and `>&-` updated the shell's bookkeeping
without making the descriptor unreachable. Both leave a descriptor the *host* process owns live and
receiving writes the script directed elsewhere — which is how a corpus run overwrote the header of
an open SQLite database and scored 0 passed / 2779 failed.

## What changed

**`exec` decides redirect-only mode after option parsing.** The rule is "if no command word
survives, the redirections become permanent". It previously lived in `execute_command`, which
branched on `cmd_args.is_empty()` — so `exec --` and `exec -a name` reached `builtin_exec`, fell
through its flag loop to `if cmd_start >= args.len()`, and returned `Ok(0)` with `active` dropped on
the floor. The decision now lives in one place, `builtin_exec`, which takes `ActiveRedirects` by
value. Per bash, an invalid option also applies the redirections before reporting itself.

**`IoContext` distinguishes *closed* from *absent*.** Absent means the shell never touched the
number, so a redirect may still resolve it against the host's real fd table — that is ordinary POSIX
inheritance and bash does the same. Closed means the script closed it: not resolvable by a later
`>&N`, and carried into every child fd table as a new `Fd::Close`. The four spawn sites (external,
pipeline, subshell, `exec`'s own child) all emit it; without it `posix_spawn` inherits the number
and hands the child whatever the host had there.

thaum never calls `close(2)` on the host's descriptor — it is not thaum's to close. Recording the
close and refusing to hand the number out is observably identical for the script and leaves the
embedder intact.

**A redirect list is last-one-wins.** `ActiveRedirects.closed_fds` was an unordered set drained
after the handle maps, so a close beat a reopen regardless of order: `{ ...; } 3>&- 3>g` aborted
with `Bad file descriptor (os error 9)` where bash writes to `g`. Contained before this PR;
promoting the set to persistent state would have leaked it forward, so it is fixed here.

**`N>&M-` / `N<&M-` are implemented.** They previously raised `ambiguous redirect` and applied
nothing, leaving the host's descriptor live — the same escape as #16 by a third route.

## Implementation note

`Fd::Close` is `adddup2(/dev/null, fd)` then `addclose(fd)`, not a bare `addclose`. On macOS,
`posix_spawn_file_actions_addclose` against a number that is not open makes the *whole spawn* fail
with EBADF and the child never runs — verified with a standalone C probe. A pre-flight
`fcntl(F_GETFD)` would be a check-then-act on a process-global table; the dup2 makes the number open
unconditionally instead. On Windows no action is needed: fds 3+ reach the child only through
`build_lpreserved2`, where an absent entry already reads as closed.

## Testing

Every expected value was derived by running the equivalent script under GNU bash 5.3.15, never by
running thaum and recording its output. `tests/exec/descriptors.rs` carries the bash invocation in a
comment beside each assertion.

The escape is proved the way it was found: a real file on a real descriptor of the test process,
which the shell never opened, must stay empty. Descriptor numbers come from `into_raw_fd` — never
`dup2` onto a literal 3, because the test process holds descriptors of its own, including skuld's
coordination database. `HostFd` re-`dup(2)`s the file so the probe is not `O_CLOEXEC`; without that
it vanished at `exec` and every "the child could not reach it" assertion passed for the wrong
reason.

The control is covered too: a child writing to a legitimately inherited descriptor still works, and
so does reopening a closed number. Both issues call that out as *not* the defect, and both are
pinned.

A new `test-writefd` test tool provides a neutral observer, so "did the child reach the descriptor?"
does not run through `dup_process_fd` — the very fallback this PR narrows. Pure `std`, no new
dependency.

## Results

Base `19bf51f`, measured locally on macOS with
`cargo nextest run --features cli --no-fail-fast -E 'not (binary(gauntlet) | binary(infra))'`:

| | tests | passed | failed |
| --- | --- | --- | --- |
| base | 1607 | 1597 | 10 |
| this branch | 1639 | 1629 | 10 |

The ten failures are identical by name before and after — the TTY/PTY cluster from #15.

Gauntlet (`THAUM_GAUNTLET_NO_SANDBOX=1`, not a gate): 1027 → **1031** passed. Three in-scope corpus
cases flip to passing, including `oils/builtin-process/exec----21`, which is literally
`exec -- 3>&1; echo stdout 1>&3` — the case that corrupted the database.
`oils/redirect/exec-fd--osh-regression-fails-to-close-fd` still fails: it uses `{fd}>file` varfd
redirections, which thaum does not implement at all.

## Out of scope, filed separately

Found while auditing the shared path, all pre-existing:

- #38 — pipeline stages ignore per-command redirections entirely (`echo a > f | cat` creates no
  file and sends the data down the pipe, with exit status 0).
- #39 — nine builtins accept `--` and then lose or misread what follows.
- #40 — `exec -c` / `exec -l` rejected as invalid options.
- #41 — the shell's own writes to a closed descriptor 0-2 hit `/dev/null` and succeed where bash
  reports EBADF. The *child* half is fixed here; the shell half needs an error path through every
  `io.fd_mut(n)` site.
